### PR TITLE
BXMSPROD-730 mailer script improved to treat also PRs

### DIFF
--- a/vars/mailer.groovy
+++ b/vars/mailer.groovy
@@ -1,6 +1,7 @@
 def sendEmailFailure() {
+    def branch = $BRANCH_NAME ?: $ghprbSourceBranch
     emailext (
-            subject: "Build $BRANCH_NAME failed",
-            body: "Build $BRANCH_NAME failed! For more information see $BUILD_URL",
+            subject: "Build $branch failed",
+            body: "Build $branch failed! For more information see $BUILD_URL",
             recipientProviders: [[$class: 'DevelopersRecipientProvider'], [$class: 'RequesterRecipientProvider']])
 }


### PR DESCRIPTION
BXMSPROD-730
The `ghprbSourceBranch` env variable comes from the github plugin we use to trigger a job based on a comment phrase. The `BRANCH_NAME` is not present in these cases