### PR TITLE
BXMSPROD-742 checks out projects at the beginning of the process

### DIFF
--- a/vars/treebuild.groovy
+++ b/vars/treebuild.groovy
@@ -5,7 +5,7 @@
  * @param goals maven goals
  * @param skipTests Boolean to skip tests or not
  */
-def downstreamBuild(def projectCollection, String settingsXmlId, String goals, Boolean skipTests = null) {
+def downstreamBuild(List<String> projectCollection, String settingsXmlId, String goals, Boolean skipTests = null) {
     println "Downstream building. Reading Lines for ${projectCollection}"
     def lastLine = projectCollection.get(projectCollection.size() - 1)
     println "Downstream building ${lastLine} project."
@@ -20,8 +20,11 @@ def downstreamBuild(def projectCollection, String settingsXmlId, String goals, B
  * @param goals maven goals
  * @param skipTests Boolean to skip tests or not
  */
-def upstreamBuild(def projectCollection, String currentProject, String settingsXmlId, String goals, Boolean skipTests = null) {
+def upstreamBuild(List<String> projectCollection, String currentProject, String settingsXmlId, String goals, Boolean skipTests = null) {
     println "Upstream building ${currentProject} project for ${projectCollection}"
+
+    checkoutProjects(projectCollection)
+
     // Build project tree from currentProject node
     for (i = 0; currentProject != projectCollection.get(i); i++) {
         buildProject(projectCollection.get(i), settingsXmlId, goals, skipTests)
@@ -43,10 +46,28 @@ def buildProject(String project, String settingsXmlId, String goals, Boolean ski
     def name = projectGroupName[1]
 
     println "Building ${group}/${name}"
-    sh "mkdir -p ${group}_${name}"
     dir("${env.WORKSPACE}/${group}_${name}") {
-        checkoutProject(name, group)
         maven.runMavenWithSettings(settingsXmlId, goals, skipTests != null ? skipTests : new Properties())
+    }
+}
+
+/**
+ * Checks out the project collection
+ *
+ * @param projectCollection the list of projects to be checked out
+ * @return
+ */
+def checkoutProjects(List<String> projectCollection) {
+    println "Checking out projects ${projectCollection}"
+
+    projectCollection.each { project ->
+        def projectGroupName = getProjectGroupName(project)
+        def group = projectGroupName[0]
+        def name = projectGroupName[1]
+        sh "mkdir -p ${group}_${name}"
+        dir("${env.WORKSPACE}/${group}_${name}") {
+            checkoutProject(name, group)
+        }
     }
 }
 

--- a/vars/treebuild.groovy
+++ b/vars/treebuild.groovy
@@ -23,14 +23,12 @@ def downstreamBuild(List<String> projectCollection, String settingsXmlId, String
 def upstreamBuild(List<String> projectCollection, String currentProject, String settingsXmlId, String goals, Boolean skipTests = null) {
     println "Upstream building ${currentProject} project for ${projectCollection}"
 
-    checkoutProjects(projectCollection)
+    checkoutProjects(projectCollection, currentProject)
 
     // Build project tree from currentProject node
-    for (i = 0; currentProject != projectCollection.get(i); i++) {
+    for (i = 0; i == 0 || currentProject != projectCollection.get(i-1); i++) {
         buildProject(projectCollection.get(i), settingsXmlId, goals, skipTests)
     }
-
-    buildProject(currentProject, settingsXmlId, goals, skipTests)
 }
 
 /**
@@ -55,13 +53,13 @@ def buildProject(String project, String settingsXmlId, String goals, Boolean ski
  * Checks out the project collection
  *
  * @param projectCollection the list of projects to be checked out
- * @return
+ * @param limitProject the project to stop
  */
-def checkoutProjects(List<String> projectCollection) {
+def checkoutProjects(List<String> projectCollection, String limitProject) {
     println "Checking out projects ${projectCollection}"
 
-    projectCollection.each { project ->
-        def projectGroupName = getProjectGroupName(project)
+    for (i = 0; i == 0 || limitProject != projectCollection.get(i-1); i++) {
+        def projectGroupName = getProjectGroupName(projectCollection.get(i))
         def group = projectGroupName[0]
         def name = projectGroupName[1]
         sh "mkdir -p ${group}_${name}"


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-742
I'm trying to minimise the possibilities of having commits between the starting of the build and the project build itself. It's a simple change I have to test but I would like to know your opinion before spending time here.
Basically I add the checkout at the beginning of the process here https://github.com/Ginxo/jenkins-pipeline-shared-libraries/blob/BXMSPROD-742/vars/treebuild.groovy#L26 and here https://github.com/Ginxo/jenkins-pipeline-shared-libraries/blob/2ff2e8adc39ae5452415ef042099e8541db1434a/vars/pmebuild.groovy#L18 then the checkout for every project is done before any build is performed.