### PR TITLE
[KOGITO-2285] Shared libaries: Git tagging

### DIFF
--- a/test/vars/GithubScmSpec.groovy
+++ b/test/vars/GithubScmSpec.groovy
@@ -1,0 +1,72 @@
+import com.homeaway.devtools.jenkins.testing.JenkinsPipelineSpecification
+import hudson.plugins.git.GitSCM
+
+class GithubScmSpec extends JenkinsPipelineSpecification {
+    def groovyScript = null
+
+    def setup() {
+        groovyScript = loadPipelineScriptForTest("vars/githubscm.groovy")
+
+        // shared setup for tagRepository 
+        explicitlyMockPipelineVariable("out")
+        getPipelineMock("sh")([returnStdout: true, script: 'git log --oneline -1']) >> {
+            return 'commitIdMock'
+        }
+
+        // shared setup for pushObject  
+        explicitlyMockPipelineVariable("GIT_USERNAME")
+        explicitlyMockPipelineVariable("GIT_PASSWORD")
+    }
+
+    def "[githubscm.groovy] tagRepository with buildTag"() {
+        when:
+            groovyScript.tagRepository('userName', 'user@email.com', 'tagName', 'buildTag')
+        then:
+            1 * getPipelineMock("sh")("git config user.name 'userName'")
+            1 * getPipelineMock("sh")("git config user.email 'user@email.com'")
+            1 * getPipelineMock("sh")("git tag -a 'tagName' -m 'Tagged by Jenkins in build \"buildTag\".'")
+    }
+
+    def "[githubscm.groovy] tagRepository without buildTag"() {
+        when:
+            groovyScript.tagRepository('userName', 'user@email.com', 'tagName')
+        then:
+            1 * getPipelineMock("sh")("git config user.name 'userName'")
+            1 * getPipelineMock("sh")("git config user.email 'user@email.com'")
+            1 * getPipelineMock("sh")("git tag -a 'tagName' -m 'Tagged by Jenkins.'")
+    }
+
+    def "[githubscm.groovy] pushObject without credentialsId"() {
+        when:
+            groovyScript.pushObject('remote', 'object')
+        then:
+            1 * getPipelineMock("usernamePassword.call").call(['credentialsId': 'kie-ci', 'usernameVariable':'GIT_USERNAME', 'passwordVariable':'GIT_PASSWORD'])
+            1 * getPipelineMock("withCredentials")(_)
+            1 * getPipelineMock("sh")("git config --local credential.helper \"!f() { echo username=\\$GIT_USERNAME; echo password=\\$GIT_PASSWORD; }; f\"")
+            1 * getPipelineMock("sh")("git push remote object")
+    }
+
+    def "[githubscm.groovy] pushObject with credentialsId"() {
+        when:
+            groovyScript.pushObject('remote', 'object', 'credsId')
+        then:
+            1 * getPipelineMock("usernamePassword.call").call(['credentialsId': 'credsId', 'usernameVariable':'GIT_USERNAME', 'passwordVariable':'GIT_PASSWORD'])
+            1 * getPipelineMock("withCredentials")(_)
+            1 * getPipelineMock("sh")("git config --local credential.helper \"!f() { echo username=\\$GIT_USERNAME; echo password=\\$GIT_PASSWORD; }; f\"")
+            1 * getPipelineMock("sh")("git push remote object")
+    }
+
+    def "[githubscm.groovy] pushObject exception"() {
+        setup:
+            getPipelineMock("sh")("git push remote object") >> {
+                throw new Exception("error when pushing")
+            }
+        when:
+            groovyScript.pushObject('remote', 'object')
+        then:
+            1 * getPipelineMock("usernamePassword.call").call(['credentialsId': 'kie-ci', 'usernameVariable':'GIT_USERNAME', 'passwordVariable':'GIT_PASSWORD'])
+            1 * getPipelineMock("withCredentials")(_)
+            1 * getPipelineMock("sh")("git config --local credential.helper \"!f() { echo username=\\$GIT_USERNAME; echo password=\\$GIT_PASSWORD; }; f\"")
+            thrown(Exception)
+    }
+}


### PR DESCRIPTION
See: https://issues.redhat.com/browse/KOGITO-2285

This PR adds a `tagRepository` function as per the issue. The core of the code is basically the same as [this CloudBees article](https://support.cloudbees.com/hc/en-us/articles/360027646491-Pipeline-Equivalent-to-Git-Publisher).  I originally used SSH for authentication but realized the existing pipelines used HTTPS, so this also uses HTTPS authentication. The structure of the function mimics `mergeSourceIntoTarget` with using the `checkout` and `resolveRepository` functions to checkout the repository and also annotates progress with info/error messages.

### Example Usage
```Jenkinsfile
stage('Tag kogito-runtimes') {
    steps {
        script {
            githubscm.tagRepository('kogito-runtimes', 'kiegroup', 'master', 'Example User', 'example@example.com', 'v2.00')
        }
    }
}
```
