### PR TITLE
KOGITO-2724 Remove Git committer parameters

### DIFF
--- a/test/vars/GithubScmSpec.groovy
+++ b/test/vars/GithubScmSpec.groovy
@@ -133,20 +133,16 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
 
     def "[githubscm.groovy] commitChanges without files to add"() {
         when:
-        groovyScript.commitChanges('userName', 'user@email.com', 'commit message')
+        groovyScript.commitChanges('commit message')
         then:
-        1 * getPipelineMock("sh")("git config user.name 'userName'")
-        1 * getPipelineMock("sh")("git config user.email 'user@email.com'")
         1 * getPipelineMock("sh")('git add --all')
         1 * getPipelineMock("sh")("git commit -m 'commit message'")
     }
 
     def "[githubscm.groovy] commitChanges with files to add"() {
         when:
-        groovyScript.commitChanges('userName', 'user@email.com', 'commit message', 'src/*')
+        groovyScript.commitChanges('commit message', 'src/*')
         then:
-        1 * getPipelineMock("sh")("git config user.name 'userName'")
-        1 * getPipelineMock("sh")("git config user.email 'user@email.com'")
         1 * getPipelineMock("sh")('git add src/*')
         1 * getPipelineMock("sh")("git commit -m 'commit message'")
     }
@@ -265,19 +261,15 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
 
     def "[githubscm.groovy] tagRepository with buildTag"() {
         when:
-        groovyScript.tagRepository('userName', 'user@email.com', 'tagName', 'buildTag')
+        groovyScript.tagRepository('tagName', 'buildTag')
         then:
-        1 * getPipelineMock("sh")("git config user.name 'userName'")
-        1 * getPipelineMock("sh")("git config user.email 'user@email.com'")
         1 * getPipelineMock("sh")("git tag -a 'tagName' -m 'Tagged by Jenkins in build \"buildTag\".'")
     }
 
     def "[githubscm.groovy] tagRepository without buildTag"() {
         when:
-        groovyScript.tagRepository('userName', 'user@email.com', 'tagName')
+        groovyScript.tagRepository('tagName')
         then:
-        1 * getPipelineMock("sh")("git config user.name 'userName'")
-        1 * getPipelineMock("sh")("git config user.email 'user@email.com'")
         1 * getPipelineMock("sh")("git tag -a 'tagName' -m 'Tagged by Jenkins.'")
     }
 

--- a/vars/githubscm.groovy
+++ b/vars/githubscm.groovy
@@ -84,9 +84,7 @@ def createBranch(String branchName) {
     println "[INFO] Created branch '${branchName}' on repo."
 }
 
-def commitChanges(String userName, String userEmail, String commitMessage, String filesToAdd = '--all') {
-    sh "git config user.name '${userName}'"
-    sh "git config user.email '${userEmail}'"
+def commitChanges(String commitMessage, String filesToAdd = '--all') {
     sh "git add ${filesToAdd}"
     sh "git commit -m '${commitMessage}'"
 }
@@ -128,21 +126,19 @@ def mergePR(String pullRequestLink, String credentialID='kie-ci') {
     }
 }
 
-// Optional: Pass in $BUILD_TAG as buildTag in pipeline script 
+// Optional: Pass in env.BUILD_TAG as buildTag in pipeline script 
 // to trace back the build from which this tag came from.
-def tagRepository(String tagUserName, String tagUserEmail, String tagName, String buildTag = '') {
+def tagRepository(String tagName, String buildTag = '') {
     def currentCommit = getCommit()
     def tagMessageEnding = buildTag ? " in build \"${buildTag}\"." : '.'
     def tagMessage = "Tagged by Jenkins${tagMessageEnding}"
-    sh "git config user.name '${tagUserName}'"
-    sh "git config user.email '${tagUserEmail}'"
     sh "git tag -a '${tagName}' -m '${tagMessage}'"
     println """
 -------------------------------------------------------------
 [INFO] Tagged current repository
 -------------------------------------------------------------
 Commit: ${currentCommit}
-Tagger: ${tagUserName} (${tagUserEmail})
+Tagger: ${env.GIT_COMMITTER_NAME} (${env.GIT_COMMITTER_EMAIL})
 Tag: ${tagName}
 Tag Message: ${tagMessage}
 -------------------------------------------------------------


### PR DESCRIPTION
See: https://issues.redhat.com/browse/KOGITO-2724

`tagRepository` and `commitChanges` tests were updated accordingly.

### Test Build
I ran [a build](https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/custom/job/kmok/job/KOGITO-2724/14/console) with the updated `commitChanges` and `tagRepository` that don't have Git committer parameters, and the resulting commit/tag have the globally set Git committer info.

Script:
```groovy
githubscm.commitChanges("Date")
sh "git log -1"

githubscm.tagRepository("$BUILD_TAG", "$BUILD_TAG")
sh "git show ${BUILD_TAG}"
```

Result:
```
...
Author: Jenkins CI <jenkins@rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com>
...
Tagger: Jenkins CI <jenkins@rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com>
```
