### PR TITLE
BXMSPROD-948 Fix arguments in getForkedProjectName call

### DIFF
--- a/test/vars/GithubScmSpec.groovy
+++ b/test/vars/GithubScmSpec.groovy
@@ -143,7 +143,7 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         1 * getPipelineMock('sh')('git pull https://user:password@github.com/author/repository branches')
         2 * getPipelineMock("sh")(['returnStdout': true, 'script': 'git log --oneline -1']) >> 'git commit information'
         1 * getPipelineMock("sh")(['returnStdout': true, 'script': "curl -H \"Authorization: token oauth_token\" 'https://api.github.com/repos/defaultAuthor/repository/pulls?head=author:branches&state=open'"]) >> pullRequestInfo
-        1 * getPipelineMock("string.call")(['credentialsId': 'ci-token', 'variable': 'OAUTHTOKEN'])
+        2 * getPipelineMock("string.call")(['credentialsId': 'ci-token', 'variable': 'OAUTHTOKEN'])
     }
 
     def "[githubscm.groovy] checkoutIfExists has not PR"() {

--- a/vars/githubscm.groovy
+++ b/vars/githubscm.groovy
@@ -15,7 +15,7 @@ def checkoutIfExists(String repository, String author, String branches, String d
     assert credentials['token']
     assert credentials['usernamePassword']
     def sourceAuthor = author
-    def sourceRepository = getForkedProjectName(defaultAuthor, repository, sourceAuthor) ?: repository
+    def sourceRepository = getForkedProjectName(defaultAuthor, repository, sourceAuthor, credentials['token']) ?: repository
     // Checks source group and branch (for cases where the branch has been created in the author's forked project)
     def repositoryScm = getRepositoryScm(sourceRepository, author, branches, credentials['usernamePassword'])
     if (repositoryScm == null) {


### PR DESCRIPTION
See: https://issues.redhat.com/browse/BXMSPROD-948

I tested this fix [in a custom build job](https://jenkins-kogito-tools.apps.kogito.automation.rhmw.io/job/Custom/job/kmok/job/operator-pr-check/5/console).
