### PR TITLE
Allow version suffix in parseVersion

### DIFF
--- a/test/vars/UtilSpec.groovy
+++ b/test/vars/UtilSpec.groovy
@@ -519,14 +519,14 @@ class UtilSpec extends JenkinsPipelineSpecification {
         when:
         def checkForAlphabets = groovyScript.getNextVersion('a.12.0', 'micro')
         then:
-        1 * getPipelineMock("error").call('Version a.12.0 is not in the required format.It should contain only numeric characters')
+        1 * getPipelineMock("error").call('Version a.12.0 is not in the required format. The major, minor, and micro parts should contain only numeric characters.')
     }
     
     def "[util.groovy] getNextVersionErrorFormat"() {
         when:
         def checkForFormatError = groovyScript.getNextVersion('0.12.0.1', 'micro')
         then:
-        1 * getPipelineMock("error").call('Version 0.12.0.1 is not in the required format X.Y.Z')
+        1 * getPipelineMock("error").call('Version 0.12.0.1 is not in the required format X.Y.Z or X.Y.Z.suffix.')
     }
     
     def "[util.groovy] getNextVersion null"() {
@@ -552,18 +552,27 @@ class UtilSpec extends JenkinsPipelineSpecification {
         version[2] == 6598
     }
 
+    def "[util.groovy] parseVersionWithSuffixCorrect"() {
+        when:
+        def version = groovyScript.parseVersion('1.0.0.Final')
+        then:
+        version[0] == 1
+        version[1] == 0
+        version[2] == 0
+    }
+
     def "[util.groovy] parseVersionErrorContainsAlphabets"() {
         when:
         groovyScript.parseVersion('a.12.0')
         then:
-        1 * getPipelineMock("error").call('Version a.12.0 is not in the required format.It should contain only numeric characters')
+        1 * getPipelineMock("error").call('Version a.12.0 is not in the required format. The major, minor, and micro parts should contain only numeric characters.')
     }
     
     def "[util.groovy] parseVersionErrorFormat"() {
         when:
         groovyScript.parseVersion('0.12.0.1')
         then:
-        1 * getPipelineMock("error").call('Version 0.12.0.1 is not in the required format X.Y.Z')
+        1 * getPipelineMock("error").call('Version 0.12.0.1 is not in the required format X.Y.Z or X.Y.Z.suffix.')
     }
 
     def "[util.groovy] generateHashSize9"() {

--- a/vars/util.groovy
+++ b/vars/util.groovy
@@ -228,24 +228,28 @@ def getNextVersion(String version, String type, String suffix = 'SNAPSHOT') {
 }
 
 /*
- * It parses a version string, which needs to be in the for X.Y.Z and returns the 3 numbers in an array.
+ * It parses a version string, which needs to be in the format X.Y.Z or X.Y.Z.suffix and returns the 3 numbers
+ * in an array. The optional suffix must not be numeric.
+ * <p>
+ * Valid version examples:
+ * 1.0.0
+ * 1.0.0.Final
 */
 Integer[] parseVersion(String version){
     String [] versionSplit = version.split("\\.")
-    if(versionSplit.length == 3) {
+    boolean hasNonNumericSuffix = versionSplit.length == 4 && !(versionSplit[3].isNumber())
+    if(versionSplit.length == 3 || hasNonNumericSuffix) {
         if(versionSplit[0].isNumber() && versionSplit[1].isNumber() && versionSplit[2].isNumber()) { 
             Integer[] vs = new Integer[3]
             vs[0] = Integer.parseInt(versionSplit[0])
             vs[1] = Integer.parseInt(versionSplit[1])
             vs[2] = Integer.parseInt(versionSplit[2])
             return vs
+        } else {
+            error "Version ${version} is not in the required format. The major, minor, and micro parts should contain only numeric characters."
         }
-        else {
-            error "Version ${version} is not in the required format.It should contain only numeric characters"
-        } 
-    }     
-    else {
-        error "Version ${version} is not in the required format X.Y.Z"
+    } else {
+        error "Version ${version} is not in the required format X.Y.Z or X.Y.Z.suffix."
     }
 }
 


### PR DESCRIPTION
Allows parsing of versions with suffixes likes:
1.0.0.Final
1.0.0.CR1
etc.

There still must be 3 numeric parts - major, minor, micro. The suffix is optional.

