### PR TITLE
[BXMSPROD-1126] Return null in getRepositoryScm when non-existent

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -43,6 +43,18 @@ pipeline {
         }
       }
     }
+
+    stage('Test getRepositoryScm') {
+      steps {
+        script {
+          def existingBranch = githubscm.getRepositoryScm(repo, changeAuthor, changeBranch)
+          assert existingBranch != null
+
+          def nonExistentBranch = githubscm.getRepositoryScm(repo, 'kiegroup', 'non-existent-branch')
+          assert nonExistentBranch == null
+        }
+      }
+    }
   }
   post {
     always {

--- a/vars/githubscm.groovy
+++ b/vars/githubscm.groovy
@@ -41,12 +41,15 @@ def checkoutIfExists(String repository, String author, String branches, String d
 }
 
 def getRepositoryScm(String repository, String author, String branches, String credentialId = 'kie-ci') {
-    println "[INFO] Resolving repository ${repository} author ${author} branches ${branches}"
-    def repositoryScm = null
-    try {
-        repositoryScm = resolveRepository(repository, author, branches, true, credentialId)
-    } catch (Exception ex) {
-        println "[WARNING] Branches [${branches}] from repository ${repository} not found in ${author} organisation."
+    def repositoryScm = resolveRepository(repository, author, branches, true, credentialId)
+    def tempDir = sh(script: 'mktemp -d', returnStdout: true).trim()
+    dir(tempDir) {
+        try {
+            checkout repositoryScm
+        } catch (Exception ex) {
+            println "[WARNING] Branches [${branches}] from repository ${repository} not found in ${author} organisation."
+            repositoryScm = null
+        }
     }
     return repositoryScm
 }


### PR DESCRIPTION
See: https://issues.redhat.com/browse/BXMSPROD-1126

This PR updates `getRepositoryScm()` to try to checkout the repository in the try/catch block and return null if the repository doesn't exist. I tested [checking out a non-existent branch](https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/custom/job/kmok/job/test/62/console) as well as [an existing one](https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/custom/job/kmok/job/test/64/console).
