### PR TITLE
Do not stage if no files was found

### DIFF
--- a/vars/githubscm.groovy
+++ b/vars/githubscm.groovy
@@ -269,7 +269,9 @@ def findAndStageNotIgnoredFiles(String findNamePattern){
         fi
     done < found_files.txt
     rm found_files.txt
-    git add \$files_to_add
+    if [ \$files_to_add ]; then
+        git add \$files_to_add
+    fi
     git status
     """
 }


### PR DESCRIPTION
While changing versions I need to stage not only pom files but build.gradle, so I pass it for staging, but not every repo has those files.

Previously returned 1 exit code if no files was found anf git add run
Added a check to not add anything and response with a status in case file was not found.

Problem build https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/custom/job/adupliak/job/quickstarts-release-pipeline/job/optaplanner-deploy/34/console

Related to https://github.com/kiegroup/optaplanner/pull/1084