### PR TITLE
[KOGITO-1031] Upload local artifacts

### DIFF
--- a/vars/maven.groovy
+++ b/vars/maven.groovy
@@ -111,6 +111,7 @@ def mvnVersionsUpdateParentAndChildModules(MavenCommand mvnCmd, String newVersio
 def mvnSetVersionProperty(String property, String newVersion) {
     mvnSetVersionProperty(new MavenCommand(this), property, newVersion)
 }
+
 def mvnSetVersionProperty(MavenCommand mvnCmd, String property, String newVersion) {
     mvnCmd.clone()
         .withOptions(['-e'])
@@ -120,3 +121,14 @@ def mvnSetVersionProperty(MavenCommand mvnCmd, String property, String newVersio
         .withProperty('generateBackupPoms', false)
         .run('versions:set-property')
 }
+
+def uploadLocalArtifacts(String mvnUploadCredsId, String artifactDir, String repoUrl) {
+    def zipFileName = 'artifacts'
+    withCredentials([usernameColonPassword(credentialsId: mvnUploadCredsId, variable: 'kieUnpack')]) {
+        dir(artifactDir) {
+            sh "zip -r ${zipFileName} ."
+            sh "curl --silent --upload-file ${zipFileName}.zip -u ${kieUnpack} -v ${repoUrl}"
+        }
+    }
+}
+


### PR DESCRIPTION
See: https://issues.redhat.com/browse/KOGITO-1031

This is an accompanying PR to [the one opened in kogito-pipelines](https://github.com/kiegroup/kogito-pipelines/pull/46). 

## Changes
- adds function to zip local artifacts and push them to Nexus
  * copied from [kie-jenkins-scripts](https://github.com/kiegroup/kie-jenkins-scripts/blob/56e91745ac98d4529b4414ecca37f5f3e87dedc3/job-dsls/jobs/dailyBuild_pipeline.groovy#L111-L114)

## Testing
I was able to [zip](https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/custom/job/kmok/job/KOGITO-1031-full/job/kogito-runtimes-deploy/79/execution/node/111/log/?consoleFull) and [push](https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/custom/job/kmok/job/KOGITO-1031-full/job/kogito-runtimes-deploy/79/execution/node/112/log/) the artifacts to the PR test repository using the helper from this PR.
