### PR TITLE
cleanWs method as first action of post buils actions (always)

### DIFF
--- a/vars/util.groovy
+++ b/vars/util.groovy
@@ -309,12 +309,14 @@ void executeWithCredentialsMap(Map credentials, Closure closure) {
 }
 
 void cleanNode(String containerEngine = '') {
+    println '[INFO] Clean workspace'
+    cleanWs()
+    println '[INFO] Workspace cleaned'
     println '[INFO] Cleanup Maven artifacts'
     maven.cleanRepository()
+    println '[INFO] .m2/repository cleaned'
     if (containerEngine) {
         println "[INFO] Cleanup ${containerEngine} containers/images"
         cloud.cleanContainersAndImages(containerEngine)
     }
-    println '[INFO] Clean workspace'
-    cleanWs()
 }


### PR DESCRIPTION
We encounter a lot of "no space left" errors on several OpenStack nodes. 
Looking at these machines you can see that there are almost two different workspaces.
A workspace should be removed once a job finishes.
We have to dive deeper in what exactly happens on these machines, but as fist step it would be good to have the `cleanWs()` as first action before doing other stuff. It seems that when removing  the `.m2/repository` and two jobs are executing on the same machine (should only theoretically be possible, depending on the number of executers) and one tries to remove the .m2 and one load up some stuff) the `.m2/repository` can't be removed and the [method](https://github.com/kiegroup/jenkins-pipeline-shared-libraries/blob/master/vars/util.groovy#L311) is not fully executed , sso the workspace isn't cleaned.