### PR TITLE
Corrected Jenkins repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,12 @@
         <repository>
             <id>jenkins-releases</id>
             <name>Jenkins Releases</name>
-            <url>http://repo.jenkins-ci.org/releases</url>
+            <url>https://repo.jenkins-ci.org/releases</url>
+        </repository>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <name>Jenkins Public</name>
+            <url>https://repo.jenkins-ci.org/public</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
             <url>https://repo.jenkins-ci.org/releases</url>
         </repository>
         <repository>
+            <!-- Repository added to overcome a dependency repository url definition still with `http` ... -->
             <id>repo.jenkins-ci.org</id>
             <name>Jenkins Public</name>
             <url>https://repo.jenkins-ci.org/public</url>


### PR DESCRIPTION
Switching as http is no more supported with Maven 3.8.1+
https://maven.apache.org/docs/3.8.1/release-notes.html