### PR TITLE
githubscm.checkoutIfExists merge mechanism improved

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,9 @@
     </repositories>
 
     <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+
         <groovy.core.version>2.4.11</groovy.core.version>
         <groovy.gmaven.pluginVersion>1.6.1</groovy.gmaven.pluginVersion>
         <google.guava.version>29.0-jre</google.guava.version>

--- a/test/vars/GithubScmSpec.groovy
+++ b/test/vars/GithubScmSpec.groovy
@@ -66,7 +66,7 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         groovyScript.checkoutIfExists('repository', 'author', 'branches', 'defaultAuthor', 'main')
         then:
         2 * getPipelineMock("checkout")(gitSCM)
-        1 * getPipelineMock("sh")(['returnStdout': true, 'script': "curl --globoff -H \"Authorization: token oauth_token\" 'https://api.github.com/repos/defaultAuthor/repository/pulls?head=author:branches&state=open'"]) >> pullRequestInfo
+        0 * getPipelineMock("sh")(['returnStdout': true, 'script': _])
     }
 
     def "[githubscm.groovy] checkoutIfExists first repo does not exist"() {
@@ -78,7 +78,7 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         0 * getPipelineMock("checkout")(null)
 
         2 * getPipelineMock("checkout")(gitSCM)
-        1 * getPipelineMock("sh")(['returnStdout': true, 'script': "curl --globoff -H \"Authorization: token oauth_token\" 'https://api.github.com/repos/defaultAuthor/repository/pulls?head=author:branches&state=open'"]) >> pullRequestInfo
+        0 * getPipelineMock("sh")(['returnStdout': true, 'script': _])
     }
 
     def "[githubscm.groovy] checkoutIfExists with merge true"() {
@@ -158,7 +158,7 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         when:
         groovyScript.checkoutIfExists('repository', 'kiegroup', 'main', 'kiegroup', 'main')
         then:
-        2 * getPipelineMock("sh")(['returnStdout': true, 'script': "curl --globoff -H \"Authorization: token oauth_token\" 'https://api.github.com/repos/kiegroup/repository/pulls?head=kiegroup:main&state=open'"]) >> pullRequestInfoEmpty
+        0 * getPipelineMock("sh")(['returnStdout': true, 'script': _])
         2 * getPipelineMock("checkout")(gitSCM)
         0 * getPipelineMock("sh")(['returnStdout': true, 'script': 'git log --oneline -1'])
     }

--- a/vars/githubscm.groovy
+++ b/vars/githubscm.groovy
@@ -29,7 +29,7 @@ def checkoutIfExists(String repository, String author, String branches, String d
         repositoryScm = getRepositoryScm(repository, defaultAuthor, branches, credentials['usernamePassword'])
         sourceAuthor = repositoryScm ? defaultAuthor : author
     }
-    if (repositoryScm != null && hasPullRequest(defaultAuthor, repository, author, branches, credentials['token'])) {
+    if (repositoryScm != null && (!mergeTarget || hasPullRequest(defaultAuthor, repository, author, branches, credentials['token']))) {
         if (mergeTarget) {
             mergeSourceIntoTarget(sourceRepository, sourceAuthor, branches, repository, defaultAuthor, defaultBranches, credentials['usernamePassword'])
         } else {


### PR DESCRIPTION
there's a very special use case where the checout information is not properly get whenever a branch has no pull requests. This PR fixes it.
Tested by https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/PROD/job/kogito.nightly/job/1.11.x/31/