### PR TITLE
get build-chain version from composite action file

### DIFF
--- a/test/resources/build-chain-action-single.yml
+++ b/test/resources/build-chain-action-single.yml
@@ -1,13 +1,13 @@
 name: 'Build Chain'
-description: 'Executes buildChain tool'
+description: 'Executes build-chain tool'
 inputs:
   github-token:
     description: "the github token"
     required: true
   definition-file:
-    description: 'The `definition-file` input for the buildChain'
+    description: 'The `definition-file` input for the build-chain'
     required: false
-    default: 'https://raw.githubusercontent.com/${GROUP}/kogito-pipelines/${BRANCH:main}/.ci/pull-request-config.yaml'
+    default: 'https://raw.githubusercontent.com/${GROUP}/droolsjbpm-build-bootstrap/${BRANCH:main}/.ci/pull-request-config.yaml'
   flow-type:
     description: "the flow to execute, it can be 'pull-request', 'full-downstream', 'single' or 'branch'"
     default: "pull-request"
@@ -23,14 +23,12 @@ inputs:
     description: "The prefix for the annotations title"
     default: ''
     required: false
-
-
 runs:
   using: "composite"
   steps:
     - name: Build Chain Tool Execution
-      id: buildChain
-      uses: kiegroup/github-action-build-chain@smcVersionString
+      id: build-chain
+      uses: kiegroup/github-action-build-chain@v2.6.17
       with:
         definition-file: ${{ inputs.definition-file }}
         flow-type: ${{ inputs.flow-type }}
@@ -38,10 +36,4 @@ runs:
         logger-level: ${{ inputs.logger-level }}
         annotations-prefix: ${{ inputs.annotations-prefix }}
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
-    - name: Cache Maven packages
-      uses: actions/cache@v2
-      with:
-        path:  ~/.m2
-        key: ${{ inputs.key-prefix }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys:  ${{ inputs.key-prefix }}-m2
+        GITHUB_TOKEN: ${{ inputs.github-token }};

--- a/test/resources/build-chain-action.yml
+++ b/test/resources/build-chain-action.yml
@@ -1,0 +1,47 @@
+name: 'Build Chain'
+description: 'Executes buildChain tool'
+inputs:
+  github-token:
+    description: "the github token"
+    required: true
+  definition-file:
+    description: 'The `definition-file` input for the buildChain'
+    required: false
+    default: 'https://raw.githubusercontent.com/${GROUP}/kogito-pipelines/${BRANCH:main}/.ci/pull-request-config.yaml'
+  flow-type:
+    description: "the flow to execute, it can be 'pull-request', 'full-downstream', 'single' or 'branch'"
+    default: "pull-request"
+    required: false
+  starting-project:
+    description: "the project to start flow from. By default is the project triggering the job"
+    required: false
+  logger-level:
+    description: "the log level. 'info' (default) | 'trace' | 'debug'"
+    default: "info"
+    required: false
+  annotations-prefix:
+    description: "The prefix for the annotations title"
+    default: ''
+    required: false
+
+
+runs:
+  using: "composite"
+  steps:
+    - name: Build Chain Tool Execution
+      id: buildChain
+      uses: kiegroup/github-action-build@smcVersionString
+      with:
+        definition-file: ${{ inputs.definition-file }}
+        flow-type: ${{ inputs.flow-type }}
+        starting-project: ${{ inputs.starting-project }}
+        logger-level: ${{ inputs.logger-level }}
+        annotations-prefix: ${{ inputs.annotations-prefix }}
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+    - name: Cache Maven packages
+      uses: actions/cache@v2
+      with:
+        path:  ~/.m2
+        key: ${{ inputs.key-prefix }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys:  ${{ inputs.key-prefix }}-m2

--- a/test/resources/build-chain-package.json
+++ b/test/resources/build-chain-package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@kie/build-chain-action",
+  "version": "AMAZING_VERSION",
+  "description": "Library to execute commands based on github projects dependencies.",
+  "main": "dist/build-chain-cli.js",
+  "author": "Enrique Mingorance Cano <emingora@redhat.com>",
+  "license": "SEE LICENSE IN LICENSE",
+  "private": false,
+  "bin": {
+    "build-chain-action": "./bin/build-chain-cli.js"
+  },
+  "scripts": {
+    "test": "jest",
+    "locktt": "locktt",
+    "lint": "eslint .",
+    "prettier": "prettier -l src/** test/**/*.js",
+    "prettier-write": "prettier --write .",
+    "lint-final": "npm run prettier && npm run lint",
+    "prepublish": "npm run lint && npm run test",
+    "ncc-build": "ncc build --minify bin/build-chain-event.js"
+  },
+  "git-pre-hooks": {
+    "pre-commit": "npm run lint && npm run prettier && npm run ncc-build && git add dist/index.js",
+    "pre-push": "npm ci"
+  },
+  "dependencies": {
+    "@actions/artifact": "^0.3.5",
+    "@actions/core": "^1.6.0",
+    "@actions/exec": "^1.1.0",
+    "@actions/glob": "^0.1.0",
+    "@kie/build-chain-configuration-reader": "^2.2.3",
+    "@octokit/rest": "^17.6.0",
+    "argparse": "^2.0.1",
+    "dotenv": "^8.2.0",
+    "fs-extra": "^9.0.0",
+    "js-yaml": "^3.14.0",
+    "tmp": "^0.2.1"
+  },
+  "devDependencies": {
+    "@zeit/ncc": "^0.22.3",
+    "eslint": "^7.10.0",
+    "eslint-config-google": "^0.14.0",
+    "eslint-config-prettier": "^6.11.0",
+    "eslint-config-standard": "^14.1.1",
+    "eslint-plugin-import": "^2.22.0",
+    "eslint-plugin-jest": "^23.19.0",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-prettier": "^3.1.4",
+    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-standard": "^4.0.1",
+    "git-pre-hooks": "^1.2.1",
+    "jest": "^25.5.1",
+    "mock-spawn": "^0.2.6",
+    "prettier": "^2.0.5"
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "modulePathIgnorePatterns": [
+      "locally_execution/"
+    ]
+  },
+  "prettier": {
+    "trailingComma": "none",
+    "arrowParens": "avoid"
+  },
+  "engines": {
+    "node": ">= 12.18.0"
+  }
+}

--- a/test/vars/BuildChainSpec.groovy
+++ b/test/vars/BuildChainSpec.groovy
@@ -1,0 +1,26 @@
+import com.homeaway.devtools.jenkins.testing.JenkinsPipelineSpecification
+
+class BuildChainSpec extends JenkinsPipelineSpecification {
+    def groovyScript = null
+
+    def setup() {
+        groovyScript = loadPipelineScriptForTest("vars/buildChain.groovy")
+        explicitlyMockPipelineVariable("out")
+    }
+
+    def "[build-chain.groovy] get BuildChain Version From CompositeAction File"() {
+        setup:
+        def actionContent = new File(getClass().getResource('/build-chain-action.yml').toURI()).text
+        def packageJsonContent = new File(getClass().getResource('/build-chain-package.json').toURI()).text
+        GroovySpy(URL, global: true, useObjenesis: true)
+        def mockURL = GroovyMock(URL)
+
+        when:
+        def result = groovyScript.getBuildChainVersionFromCompositeActionFile('buildChain-action.yml')
+        then:
+        1 * getPipelineMock('readFile')('buildChain-action.yml') >> { return actionContent }
+        1 * new URL('https://raw.githubusercontent.com/kiegroup/github-action-build-chain/smcVersionString/package.json') >> mockURL
+        1 * mockURL.getText() >> packageJsonContent
+        result == 'AMAZING_VERSION'
+    }
+}

--- a/test/vars/BuildChainSpec.groovy
+++ b/test/vars/BuildChainSpec.groovy
@@ -23,4 +23,20 @@ class BuildChainSpec extends JenkinsPipelineSpecification {
         1 * mockURL.getText() >> packageJsonContent
         result == 'AMAZING_VERSION'
     }
+
+    def "[build-chain.groovy] get BuildChain Version From CompositeAction File from single action file"() {
+        setup:
+        def actionContent = new File(getClass().getResource('/build-chain-action-single.yml').toURI()).text
+        def packageJsonContent = new File(getClass().getResource('/build-chain-package.json').toURI()).text
+        GroovySpy(URL, global: true, useObjenesis: true)
+        def mockURL = GroovyMock(URL)
+
+        when:
+        def result = groovyScript.getBuildChainVersionFromCompositeActionFile('build-chain-action-single.yml')
+        then:
+        1 * getPipelineMock('readFile')('build-chain-action-single.yml') >> { return actionContent }
+        1 * new URL('https://raw.githubusercontent.com/kiegroup/github-action-build-chain/v2.6.17/package.json') >> mockURL
+        1 * mockURL.getText() >> packageJsonContent
+        result == 'AMAZING_VERSION'
+    }
 }

--- a/test/vars/GithubScmSpec.groovy
+++ b/test/vars/GithubScmSpec.groovy
@@ -111,7 +111,7 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         1 * getPipelineMock('usernameColonPassword.call')([credentialsId: 'kie-ci', variable: 'kieCiUserPassword']) >> 'userNamePassword'
         1 * getPipelineMock("withCredentials")(['userNamePassword'], _ as Closure)
         1 * getPipelineMock('checkout')(repositoryScmInformationMain)
-        1 * getPipelineMock('sh')('git pull https://user:password@github.com/irtyamine/github-action-buildChain branches')
+        1 * getPipelineMock('sh')('git pull https://user:password@github.com/irtyamine/github-action-build-chain branches')
         2 * getPipelineMock("sh")(['returnStdout': true, 'script': 'git log --oneline -1']) >> 'git commit information'
         1 * getPipelineMock("sh")(['returnStdout': true, 'script': "curl --globoff -H \"Authorization: token oauth_token\" 'https://api.github.com/repos/defaultAuthor/repository/pulls?head=irtyamine:branches&state=open'"]) >> pullRequestInfo
     }
@@ -499,7 +499,7 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         1 * getPipelineMock("sh")('git config --local credential.helper "!f() { echo username=\\user; echo password=\\password; }; f"')
         1 * getPipelineMock("sh")("git push remote --tags tagName")
     }
-    
+
     def "[githubscm.groovy] isTagExist ok"() {
         when:
         def output = groovyScript.isTagExist('remote', 'tagName')
@@ -783,7 +783,7 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         then:
         1 * getPipelineMock("sh")(['returnStdout': true, 'script': "curl -H \"Authorization: token oauth_token\" 'https://api.github.com/repos/groupx/repox/forks?per_page=100&page=1'"]) >> forkListInfo
         0 * getPipelineMock("sh")(['returnStdout': true, 'script': "curl -H \"Authorization: token oauth_token\" 'https://api.github.com/repos/groupx/repox/forks?per_page=100&page=2'"])
-        'github-action-buildChain' == result
+        'github-action-build-chain' == result
     }
 
     def "[githubscm.groovy] getForkedProject no existing"() {
@@ -848,7 +848,7 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         then:
         2 * getPipelineMock("sh")(['returnStdout': true, 'script': "curl -H \"Authorization: token oauth_token\" 'https://api.github.com/repos/groupx/repox/forks?per_page=100&page=1'"]) >> forkListInfoMissingOwner
         1 * getPipelineMock("sh")(['returnStdout': true, 'script': "curl -H \"Authorization: token oauth_token\" 'https://api.github.com/repos/groupx/repox/forks?per_page=100&page=1'"]) >> forkListInfo
-        'github-action-buildChain' == result
+        'github-action-build-chain' == result
     }
 
     def "[githubscm.groovy] isThereAnyChanges no change"() {

--- a/test/vars/GithubScmSpec.groovy
+++ b/test/vars/GithubScmSpec.groovy
@@ -111,7 +111,7 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         1 * getPipelineMock('usernameColonPassword.call')([credentialsId: 'kie-ci', variable: 'kieCiUserPassword']) >> 'userNamePassword'
         1 * getPipelineMock("withCredentials")(['userNamePassword'], _ as Closure)
         1 * getPipelineMock('checkout')(repositoryScmInformationMain)
-        1 * getPipelineMock('sh')('git pull https://user:password@github.com/irtyamine/github-action-build-chain branches')
+        1 * getPipelineMock('sh')('git pull https://user:password@github.com/irtyamine/github-action-buildChain branches')
         2 * getPipelineMock("sh")(['returnStdout': true, 'script': 'git log --oneline -1']) >> 'git commit information'
         1 * getPipelineMock("sh")(['returnStdout': true, 'script': "curl --globoff -H \"Authorization: token oauth_token\" 'https://api.github.com/repos/defaultAuthor/repository/pulls?head=irtyamine:branches&state=open'"]) >> pullRequestInfo
     }
@@ -783,7 +783,7 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         then:
         1 * getPipelineMock("sh")(['returnStdout': true, 'script': "curl -H \"Authorization: token oauth_token\" 'https://api.github.com/repos/groupx/repox/forks?per_page=100&page=1'"]) >> forkListInfo
         0 * getPipelineMock("sh")(['returnStdout': true, 'script': "curl -H \"Authorization: token oauth_token\" 'https://api.github.com/repos/groupx/repox/forks?per_page=100&page=2'"])
-        'github-action-build-chain' == result
+        'github-action-buildChain' == result
     }
 
     def "[githubscm.groovy] getForkedProject no existing"() {
@@ -848,7 +848,7 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         then:
         2 * getPipelineMock("sh")(['returnStdout': true, 'script': "curl -H \"Authorization: token oauth_token\" 'https://api.github.com/repos/groupx/repox/forks?per_page=100&page=1'"]) >> forkListInfoMissingOwner
         1 * getPipelineMock("sh")(['returnStdout': true, 'script': "curl -H \"Authorization: token oauth_token\" 'https://api.github.com/repos/groupx/repox/forks?per_page=100&page=1'"]) >> forkListInfo
-        'github-action-build-chain' == result
+        'github-action-buildChain' == result
     }
 
     def "[githubscm.groovy] isThereAnyChanges no change"() {

--- a/vars/buildChain.groovy
+++ b/vars/buildChain.groovy
@@ -1,0 +1,25 @@
+import groovy.json.JsonSlurper
+import org.yaml.snakeyaml.Yaml
+
+/*
+* It gets buildChain verion from composite action.yml file
+*/
+def getBuildChainVersionFromCompositeActionFile(String actionFilePath = '.ci/actions/buildChain/action.yml', String usesContainingString = 'github-action-build@') {
+    def actionFileContent = readFile actionFilePath
+    def actionObject = new Yaml().load(actionFileContent)
+
+    def uses = actionObject.runs.steps.uses
+    def action = uses != null ? uses.find({ it.contains(usesContainingString) }) : null
+    if (action == null) {
+        throw new RuntimeException("There's not steps with 'uses' for build-chain ${usesContainingString}")
+    }
+
+    def buildChainScmRevision = action.substring(action.indexOf('@') + 1)
+    try {
+        def url = new URL("https://raw.githubusercontent.com/kiegroup/github-action-build-chain/${buildChainScmRevision}/package.json")
+        def packageJson = url.getText()
+        return new JsonSlurper().parseText(packageJson).version
+    } catch(FileNotFoundException e) {
+        throw new RuntimeException("There's not scmRevision '${buildChainScmRevision}' for kiegroup/github-action-build-chain repository")
+    }
+}

--- a/vars/buildChain.groovy
+++ b/vars/buildChain.groovy
@@ -4,7 +4,7 @@ import org.yaml.snakeyaml.Yaml
 /*
 * It gets buildChain verion from composite action.yml file
 */
-def getBuildChainVersionFromCompositeActionFile(String actionFilePath = '.ci/actions/build-chain/action.yml', String usesContainingString = 'github-action-build@') {
+def getBuildChainVersionFromCompositeActionFile(String actionFilePath = '.ci/actions/build-chain/action.yml', String usesContainingString = 'github-action-build-chain@') {
     def actionFileContent = readFile actionFilePath
     def actionObject = new Yaml().load(actionFileContent)
 

--- a/vars/buildChain.groovy
+++ b/vars/buildChain.groovy
@@ -4,7 +4,7 @@ import org.yaml.snakeyaml.Yaml
 /*
 * It gets buildChain verion from composite action.yml file
 */
-def getBuildChainVersionFromCompositeActionFile(String actionFilePath = '.ci/actions/buildChain/action.yml', String usesContainingString = 'github-action-build@') {
+def getBuildChainVersionFromCompositeActionFile(String actionFilePath = '.ci/actions/build-chain/action.yml', String usesContainingString = 'github-action-build@') {
     def actionFileContent = readFile actionFilePath
     def actionObject = new Yaml().load(actionFileContent)
 


### PR DESCRIPTION
tested by https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/main/job/pullrequest/job/droolsjbpm-build-bootstrap-main.pr/242/console

```
12:01:31  build-chain version recovered 2.3.23
[Pipeline] sh
12:01:31  + npm install -g @kie/build-chain-action@2.3.23 -registry=https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/

12:01:37  /home/jenkins/tools/jenkins.plugins.nodejs.tools.NodeJSInstallation/nodejs-12.16.3/bin/build-chain-action -> /home/jenkins/tools/jenkins.plugins.nodejs.tools.NodeJSInstallation/nodejs-12.16.3/lib/node_modules/@kie/build-chain-action/bin/build-chain-cli.js
12:01:37  npm WARN notsup Unsupported engine for @kie/build-chain-action@2.3.23: wanted: {"node":">= 12.18.0"} (current: {"node":"12.16.3","npm":"6.14.4"})
12:01:37  npm WARN notsup Not compatible with your version of node/npm: @kie/build-chain-action@2.3.23
12:01:37  npm WARN @octokit/plugin-request-log@1.0.4 requires a peer of @octokit/core@>=3 but none is installed. You must install peer dependencies yourself.
12:01:37  
12:01:37  + @kie/build-chain-action@2.3.23
12:01:37  updated 1 package in 4.39s
```