### PR TITLE
Setup Zulip notification with test results

### DIFF
--- a/test/vars/MailerSpec.groovy
+++ b/test/vars/MailerSpec.groovy
@@ -1,10 +1,11 @@
 import com.homeaway.devtools.jenkins.testing.JenkinsPipelineSpecification
 
 class MailerSpec extends JenkinsPipelineSpecification {
+
     def groovyScript = null
 
     def setup() {
-        groovyScript = loadPipelineScriptForTest("vars/mailer.groovy")
+        groovyScript = loadPipelineScriptForTest('vars/mailer.groovy')
         groovyScript.metaClass.WORKSPACE = '/'
     }
 
@@ -12,71 +13,70 @@ class MailerSpec extends JenkinsPipelineSpecification {
         setup:
         def env = [:]
         env['ghprbSourceBranch'] = 'PR_1'
-        groovyScript.getBinding().setVariable("env", env)
-        groovyScript.getBinding().setVariable("BUILD_URL", 'https://redhat.com/')
+        groovyScript.getBinding().setVariable('env', env)
+        groovyScript.getBinding().setVariable('BUILD_URL', 'https://redhat.com/')
         when:
         groovyScript.sendEmailFailure()
         then:
-        1 * getPipelineMock("emailext")(['subject': 'Build PR_1 failed', body: 'Build PR_1 failed! For more information see https://redhat.com/', 'recipientProviders': [['$class': 'DevelopersRecipientProvider'], ['$class': 'RequesterRecipientProvider']]])
+        1 * getPipelineMock('emailext')(['subject': 'Build PR_1 failed', body: 'Build PR_1 failed! For more information see https://redhat.com/', 'recipientProviders': [['$class': 'DevelopersRecipientProvider'], ['$class': 'RequesterRecipientProvider']]])
     }
 
     def "[mailer.groovy] sendEmailFailure with CHANGE_BRANCH"() {
         setup:
         def env = [:]
         env['CHANGE_BRANCH'] = 'main'
-        groovyScript.getBinding().setVariable("env", env)
-        groovyScript.getBinding().setVariable("BUILD_URL", 'https://redhat.com/')
+        groovyScript.getBinding().setVariable('env', env)
+        groovyScript.getBinding().setVariable('BUILD_URL', 'https://redhat.com/')
         when:
         groovyScript.sendEmailFailure()
         then:
-        1 * getPipelineMock("emailext")(['subject': 'Build main failed', body: 'Build main failed! For more information see https://redhat.com/', 'recipientProviders': [['$class': 'DevelopersRecipientProvider'], ['$class': 'RequesterRecipientProvider']]])
+        1 * getPipelineMock('emailext')(['subject': 'Build main failed', body: 'Build main failed! For more information see https://redhat.com/', 'recipientProviders': [['$class': 'DevelopersRecipientProvider'], ['$class': 'RequesterRecipientProvider']]])
     }
 
     def "[mailer.groovy] sendEmail_failedPR with additional subject"() {
         setup:
-        groovyScript.getBinding().setVariable("ghprbPullId", '1')
-        groovyScript.getBinding().setVariable("ghprbGhRepository", '2')
-        groovyScript.getBinding().setVariable("ghprbPullTitle", '3')
-        groovyScript.getBinding().setVariable("BUILD_URL", 'https://redhat.com/')
+        groovyScript.getBinding().setVariable('ghprbPullId', '1')
+        groovyScript.getBinding().setVariable('ghprbGhRepository', '2')
+        groovyScript.getBinding().setVariable('ghprbPullTitle', '3')
+        groovyScript.getBinding().setVariable('BUILD_URL', 'https://redhat.com/')
         when:
         groovyScript.sendEmail_failedPR('additional subject')
         then:
-        1 * getPipelineMock("emailext")(['subject': 'additional subject #1 of 2: 3 failed', body: '''
-                   Pull request #1 of 2: 3 FAILED
-                   Build log: https://redhat.com/consoleText
-                   Failed tests ${TEST_COUNTS,var="fail"}: https://redhat.com/testReport
-                   (IMPORTANT: For visiting the links you need to have access to Red Hat VPN. In case you don't have access to RedHat VPN please download and decompress attached file.)
-                   ''', 'attachmentsPattern': "error.log.gz", 'recipientProviders': [['$class': 'DevelopersRecipientProvider'], ['$class': 'RequesterRecipientProvider']]])
-    }
-
-    def "[mailer.groovy] sendEmail_failedPR without additional subject"() {
-        setup:
-        groovyScript.getBinding().setVariable("ghprbPullId", '1')
-        groovyScript.getBinding().setVariable("ghprbGhRepository", '2')
-        groovyScript.getBinding().setVariable("ghprbPullTitle", '3')
-        groovyScript.getBinding().setVariable("BUILD_URL", 'https://redhat.com/')
-        when:
-        groovyScript.sendEmail_failedPR()
-        then:
-        1 * getPipelineMock("emailext")(['subject': 'PR #1 of 2: 3 failed', body: '''
+        1 * getPipelineMock('emailext')(['subject': 'additional subject #1 of 2: 3 failed', body: '''
                    Pull request #1 of 2: 3 FAILED
                    Build log: https://redhat.com/consoleText
                    Failed tests ${TEST_COUNTS,var="fail"}: https://redhat.com/testReport
                    (IMPORTANT: For visiting the links you need to have access to Red Hat VPN. In case you don't have access to RedHat VPN please download and decompress attached file.)
                    ''', 'attachmentsPattern': 'error.log.gz', 'recipientProviders': [['$class': 'DevelopersRecipientProvider'], ['$class': 'RequesterRecipientProvider']]])
+    }
 
+    def "[mailer.groovy] sendEmail_failedPR without additional subject"() {
+        setup:
+        groovyScript.getBinding().setVariable('ghprbPullId', '1')
+        groovyScript.getBinding().setVariable('ghprbGhRepository', '2')
+        groovyScript.getBinding().setVariable('ghprbPullTitle', '3')
+        groovyScript.getBinding().setVariable('BUILD_URL', 'https://redhat.com/')
+        when:
+        groovyScript.sendEmail_failedPR()
+        then:
+        1 * getPipelineMock('emailext')(['subject': 'PR #1 of 2: 3 failed', body: '''
+                   Pull request #1 of 2: 3 FAILED
+                   Build log: https://redhat.com/consoleText
+                   Failed tests ${TEST_COUNTS,var="fail"}: https://redhat.com/testReport
+                   (IMPORTANT: For visiting the links you need to have access to Red Hat VPN. In case you don't have access to RedHat VPN please download and decompress attached file.)
+                   ''', 'attachmentsPattern': 'error.log.gz', 'recipientProviders': [['$class': 'DevelopersRecipientProvider'], ['$class': 'RequesterRecipientProvider']]])
     }
 
     def "[mailer.groovy] sendEmail_unstablePR with additional subject"() {
         setup:
-        groovyScript.getBinding().setVariable("ghprbPullId", '1')
-        groovyScript.getBinding().setVariable("ghprbGhRepository", '2')
-        groovyScript.getBinding().setVariable("ghprbPullTitle", '3')
-        groovyScript.getBinding().setVariable("BUILD_URL", 'https://redhat.com/')
+        groovyScript.getBinding().setVariable('ghprbPullId', '1')
+        groovyScript.getBinding().setVariable('ghprbGhRepository', '2')
+        groovyScript.getBinding().setVariable('ghprbPullTitle', '3')
+        groovyScript.getBinding().setVariable('BUILD_URL', 'https://redhat.com/')
         when:
         groovyScript.sendEmail_unstablePR('additional subject')
         then:
-        1 * getPipelineMock("emailext")(['subject': 'additional subject #1 of 2: 3 was unstable', body: '''
+        1 * getPipelineMock('emailext')(['subject': 'additional subject #1 of 2: 3 was unstable', body: '''
                    Pull request #1 of 2: 3 was UNSTABLE
                    Build log: https://redhat.com/consoleText
                    Failed tests ${TEST_COUNTS,var="fail"}: https://redhat.com/testReport
@@ -88,14 +88,14 @@ class MailerSpec extends JenkinsPipelineSpecification {
 
     def "[mailer.groovy] sendEmail_unstablePR without additional subject"() {
         setup:
-        groovyScript.getBinding().setVariable("ghprbPullId", '1')
-        groovyScript.getBinding().setVariable("ghprbGhRepository", '2')
-        groovyScript.getBinding().setVariable("ghprbPullTitle", '3')
-        groovyScript.getBinding().setVariable("BUILD_URL", 'https://redhat.com/')
+        groovyScript.getBinding().setVariable('ghprbPullId', '1')
+        groovyScript.getBinding().setVariable('ghprbGhRepository', '2')
+        groovyScript.getBinding().setVariable('ghprbPullTitle', '3')
+        groovyScript.getBinding().setVariable('BUILD_URL', 'https://redhat.com/')
         when:
         groovyScript.sendEmail_unstablePR()
         then:
-        1 * getPipelineMock("emailext")(['subject': 'PR #1 of 2: 3 was unstable', body: '''
+        1 * getPipelineMock('emailext')(['subject': 'PR #1 of 2: 3 was unstable', body: '''
                    Pull request #1 of 2: 3 was UNSTABLE
                    Build log: https://redhat.com/consoleText
                    Failed tests ${TEST_COUNTS,var="fail"}: https://redhat.com/testReport
@@ -107,255 +107,87 @@ class MailerSpec extends JenkinsPipelineSpecification {
 
     def "[mailer.groovy] sendEmail_fixedPR with additional subject"() {
         setup:
-        groovyScript.getBinding().setVariable("ghprbPullId", '1')
-        groovyScript.getBinding().setVariable("ghprbGhRepository", '2')
-        groovyScript.getBinding().setVariable("ghprbPullTitle", '3')
+        groovyScript.getBinding().setVariable('ghprbPullId', '1')
+        groovyScript.getBinding().setVariable('ghprbGhRepository', '2')
+        groovyScript.getBinding().setVariable('ghprbPullTitle', '3')
         when:
-        groovyScript.sendEmail_fixedPR("additional subject")
+        groovyScript.sendEmail_fixedPR('additional subject')
         then:
-        1 * getPipelineMock("emailext")(['subject': 'additional subject #1 of 2: 3 is fixed and was SUCCESSFUL', 'body': '', 'recipientProviders': [['$class': 'DevelopersRecipientProvider'], ['$class': 'RequesterRecipientProvider']]])
+        1 * getPipelineMock('emailext')(['subject': 'additional subject #1 of 2: 3 is fixed and was SUCCESSFUL', 'body': '', 'recipientProviders': [['$class': 'DevelopersRecipientProvider'], ['$class': 'RequesterRecipientProvider']]])
     }
 
     def "[mailer.groovy] sendEmail_fixedPR without additional subject"() {
         setup:
-        groovyScript.getBinding().setVariable("ghprbPullId", '1')
-        groovyScript.getBinding().setVariable("ghprbGhRepository", '2')
-        groovyScript.getBinding().setVariable("ghprbPullTitle", '3')
+        groovyScript.getBinding().setVariable('ghprbPullId', '1')
+        groovyScript.getBinding().setVariable('ghprbGhRepository', '2')
+        groovyScript.getBinding().setVariable('ghprbPullTitle', '3')
         when:
         groovyScript.sendEmail_fixedPR()
         then:
-        1 * getPipelineMock("emailext")(['subject': 'PR #1 of 2: 3 is fixed and was SUCCESSFUL', 'body': '', 'recipientProviders': [['$class': 'DevelopersRecipientProvider'], ['$class': 'RequesterRecipientProvider']]])
+        1 * getPipelineMock('emailext')(['subject': 'PR #1 of 2: 3 is fixed and was SUCCESSFUL', 'body': '', 'recipientProviders': [['$class': 'DevelopersRecipientProvider'], ['$class': 'RequesterRecipientProvider']]])
     }
 
     def "[mailer.groovy] sendEmail_abortedPR with additional subject"() {
         setup:
-        groovyScript.getBinding().setVariable("ghprbPullId", '1')
-        groovyScript.getBinding().setVariable("ghprbGhRepository", '2')
-        groovyScript.getBinding().setVariable("ghprbPullTitle", '3')
+        groovyScript.getBinding().setVariable('ghprbPullId', '1')
+        groovyScript.getBinding().setVariable('ghprbGhRepository', '2')
+        groovyScript.getBinding().setVariable('ghprbPullTitle', '3')
         when:
-        groovyScript.sendEmail_abortedPR("additional subject")
+        groovyScript.sendEmail_abortedPR('additional subject')
         then:
-        1 * getPipelineMock("emailext")(['subject': 'additional subject #1 of 2: 3 was ABORTED', 'body': '', 'recipientProviders': [['$class': 'DevelopersRecipientProvider'], ['$class': 'RequesterRecipientProvider']]])
+        1 * getPipelineMock('emailext')(['subject': 'additional subject #1 of 2: 3 was ABORTED', 'body': '', 'recipientProviders': [['$class': 'DevelopersRecipientProvider'], ['$class': 'RequesterRecipientProvider']]])
     }
 
     def "[mailer.groovy] sendEmail_abortedPR without additional subject"() {
         setup:
-        groovyScript.getBinding().setVariable("ghprbPullId", '1')
-        groovyScript.getBinding().setVariable("ghprbGhRepository", '2')
-        groovyScript.getBinding().setVariable("ghprbPullTitle", '3')
+        groovyScript.getBinding().setVariable('ghprbPullId', '1')
+        groovyScript.getBinding().setVariable('ghprbGhRepository', '2')
+        groovyScript.getBinding().setVariable('ghprbPullTitle', '3')
         when:
         groovyScript.sendEmail_abortedPR()
         then:
-        1 * getPipelineMock("emailext")(['subject': 'PR #1 of 2: 3 was ABORTED', 'body': '', 'recipientProviders': [['$class': 'DevelopersRecipientProvider'], ['$class': 'RequesterRecipientProvider']]])
+        1 * getPipelineMock('emailext')(['subject': 'PR #1 of 2: 3 was ABORTED', 'body': '', 'recipientProviders': [['$class': 'DevelopersRecipientProvider'], ['$class': 'RequesterRecipientProvider']]])
     }
 
     def "[mailer.groovy] build Log Script PR"() {
         when:
         groovyScript.buildLogScriptPR()
         then:
-        1 * getPipelineMock("sh")('touch trace.sh')
-        1 * getPipelineMock("sh")('chmod 755 trace.sh')
-        1 * getPipelineMock("sh")('echo "wget --no-check-certificate ${BUILD_URL}consoleText" >> trace.sh')
-        1 * getPipelineMock("sh")('echo "tail -n 750 consoleText >> error.log" >> trace.sh')
-        1 * getPipelineMock("sh")('echo "gzip error.log" >> trace.sh')
+        1 * getPipelineMock('sh')('touch trace.sh')
+        1 * getPipelineMock('sh')('chmod 755 trace.sh')
+        1 * getPipelineMock('sh')('echo "wget --no-check-certificate ${BUILD_URL}consoleText" >> trace.sh')
+        1 * getPipelineMock('sh')('echo "tail -n 750 consoleText >> error.log" >> trace.sh')
+        1 * getPipelineMock('sh')('echo "gzip error.log" >> trace.sh')
     }
 
-    def "[mailer.groovy] sendZulipTestSummaryNotification with no build url and job success"() {
+    def "[mailer.groovy] sendMarkdownTestSummaryNotification with no build url"() {
         setup:
-        groovyScript.getBinding().setVariable("BUILD_URL", 'URL/')
-        groovyScript.getBinding().setVariable("BUILD_NUMBER", '256')
-        def jobMock = [ result: 'RESULT' ]
+        groovyScript.getBinding().setVariable('BUILD_URL', 'URL/')
         when:
-        groovyScript.sendZulipTestSummaryNotification('SUBJECT', ['email@anything.com'])
+        groovyScript.sendMarkdownTestSummaryNotification('JOB_ID', 'SUBJECT', ['email@anything.com'])
         then:
-        1 * getPipelineMock("util.retrieveArtifact")(['console.log', 'URL/']) >> ''
-        1 * getPipelineMock("util.retrieveConsoleLog")([100, 'URL/']) >> 'this is the console'
-        1 * getPipelineMock("util.retrieveJobInformation")('URL/') >> jobMock
-        1 * getPipelineMock('util.isJobResultSuccess')('RESULT') >> true
-        1 * getPipelineMock('emailext')([ subject: 'SUBJECT', to: 'email@anything.com', body: '''
-**Deploy job** #256 was: **RESULT**
-'''
-        ])
+        1 * getPipelineMock('util.getMarkdownTestSummary')('JOB_ID', 'URL/') >> 'CONTENT'
+        1 * getPipelineMock('emailext')([ subject: 'SUBJECT', to: 'email@anything.com', body: 'CONTENT'])
     }
 
-    def "[mailer.groovy] sendZulipTestSummaryNotification with build url, job success"() {
+    def "[mailer.groovy] sendMarkdownTestSummaryNotification with build url"() {
         setup:
-        groovyScript.getBinding().setVariable("BUILD_URL", 'URL/')
-        groovyScript.getBinding().setVariable("BUILD_NUMBER", '256')
-        def jobMock = [ result: 'RESULT' ]
+        groovyScript.getBinding().setVariable('BUILD_URL', 'URL/')
         when:
-        groovyScript.sendZulipTestSummaryNotification('SUBJECT', ['email@anything.com'], 'BUILD_URL/')
+        groovyScript.sendMarkdownTestSummaryNotification('JOB_ID', 'SUBJECT', ['email@anything.com'], 'BUILD_URL/')
         then:
-        1 * getPipelineMock("util.retrieveArtifact")(['console.log', 'BUILD_URL/']) >> ''
-        1 * getPipelineMock("util.retrieveConsoleLog")([100, 'BUILD_URL/']) >> 'this is the console'
-        1 * getPipelineMock("util.retrieveJobInformation")('BUILD_URL/') >> jobMock
-        1 * getPipelineMock('util.isJobResultSuccess')('RESULT') >> true
-        1 * getPipelineMock('emailext')([ subject: 'SUBJECT', to: 'email@anything.com', body: '''
-**Deploy job** #256 was: **RESULT**
-'''
-        ])
+        1 * getPipelineMock('util.getMarkdownTestSummary')('JOB_ID', 'BUILD_URL/') >> 'CONTENT'
+        1 * getPipelineMock('emailext')([ subject: 'SUBJECT', to: 'email@anything.com', body: 'CONTENT'])
     }
 
-    def "[mailer.groovy] sendZulipTestSummaryNotification with no build url, job success multiple emails"() {
+    def "[mailer.groovy] sendMarkdownTestSummaryNotification with multiple emails"() {
         setup:
-        groovyScript.getBinding().setVariable("BUILD_URL", 'URL/')
-        groovyScript.getBinding().setVariable("BUILD_NUMBER", '256')
-        def jobMock = [ result: 'RESULT' ]
+        groovyScript.getBinding().setVariable('BUILD_URL', 'URL/')
         when:
-        groovyScript.sendZulipTestSummaryNotification('SUBJECT', ['email@anything.com', 'second_email@anything.com'])
+        groovyScript.sendMarkdownTestSummaryNotification('JOB_ID', 'SUBJECT', ['email@anything.com', 'email@otherthing.com'])
         then:
-        1 * getPipelineMock("util.retrieveArtifact")(['console.log', 'URL/']) >> ''
-        1 * getPipelineMock("util.retrieveConsoleLog")([100, 'URL/']) >> 'this is the console'
-        1 * getPipelineMock("util.retrieveJobInformation")('URL/') >> jobMock
-        1 * getPipelineMock('util.isJobResultSuccess')('RESULT') >> true
-        1 * getPipelineMock('emailext')([ subject: 'SUBJECT', to: 'email@anything.com,second_email@anything.com', body: '''
-**Deploy job** #256 was: **RESULT**
-'''
-        ])
-    }
-
-    def "[mailer.groovy] sendZulipTestSummaryNotification with job fails"() {
-        setup:
-        groovyScript.getBinding().setVariable("BUILD_URL", 'URL/')
-        groovyScript.getBinding().setVariable("BUILD_NUMBER", '256')
-        def jobMock = [ result: 'FAILURE' ]
-        def testResultsMock = [ passCount: 254, failCount: 635 ]
-        def failedTestsMock = [ [ fullName: 'FULL_NAME1', url: 'FIRST_TEST_URL' ], [ fullName: 'FULL_NAME2', url: 'SECOND_TEST_URL' ]]
-        when:
-        groovyScript.sendZulipTestSummaryNotification('SUBJECT', ['email@anything.com'])
-        then:
-        1 * getPipelineMock("util.retrieveArtifact")(['console.log', 'URL/']) >> ''
-        1 * getPipelineMock("util.retrieveConsoleLog")([100, 'URL/']) >> 'this is the console'
-        1 * getPipelineMock("util.retrieveJobInformation")('URL/') >> jobMock
-        1 * getPipelineMock('util.isJobResultSuccess')('FAILURE') >> false
-        1 * getPipelineMock("util.retrieveTestResults")('URL/') >> testResultsMock
-        1 * getPipelineMock("util.retrieveFailedTests")('URL/') >> failedTestsMock
-        1 * getPipelineMock('emailext')([ subject: 'SUBJECT', to: 'email@anything.com', body: '''
-**Deploy job** #256 was: **FAILURE**
-Possible explanation: Pipeline failure or project build failure
-
-
-**Test results:**
-- PASSED: 254
-- FAILED: 635
-
-Those are the test failures: 
-- [FULL_NAME1](FIRST_TEST_URL)
-- [FULL_NAME2](SECOND_TEST_URL)
-
-
-Please look here: URL/ or see console log:
-
-```spoiler Logs
-this is the console
-```
-'''
-        ])
-    }
-
-    def "[mailer.groovy] sendZulipTestSummaryNotification with job fails and console artifact existing"() {
-        setup:
-        groovyScript.getBinding().setVariable("BUILD_URL", 'URL/')
-        groovyScript.getBinding().setVariable("BUILD_NUMBER", '256')
-        def jobMock = [ result: 'FAILURE' ]
-        def testResultsMock = [ passCount: 254, failCount: 635 ]
-        def failedTestsMock = [ [ fullName: 'FULL_NAME1', url: 'FIRST_TEST_URL' ], [ fullName: 'FULL_NAME2', url: 'SECOND_TEST_URL' ]]
-        when:
-        groovyScript.sendZulipTestSummaryNotification('SUBJECT', ['email@anything.com'])
-        then:
-        1 * getPipelineMock("util.retrieveArtifact")(['console.log', 'URL/']) >> 'this is the console artifact'
-        0 * getPipelineMock("util.retrieveConsoleLog")([100, 'URL/']) >> 'this is the console'
-        1 * getPipelineMock("util.retrieveJobInformation")('URL/') >> jobMock
-        1 * getPipelineMock('util.isJobResultSuccess')('FAILURE') >> false
-        1 * getPipelineMock("util.retrieveTestResults")('URL/') >> testResultsMock
-        1 * getPipelineMock("util.retrieveFailedTests")('URL/') >> failedTestsMock
-        1 * getPipelineMock('emailext')([ subject: 'SUBJECT', to: 'email@anything.com', body: '''
-**Deploy job** #256 was: **FAILURE**
-Possible explanation: Pipeline failure or project build failure
-
-
-**Test results:**
-- PASSED: 254
-- FAILED: 635
-
-Those are the test failures: 
-- [FULL_NAME1](FIRST_TEST_URL)
-- [FULL_NAME2](SECOND_TEST_URL)
-
-
-Please look here: URL/ or see console log:
-
-```spoiler Logs
-this is the console artifact
-```
-'''
-        ])
-    }
-
-    def "[mailer.groovy] sendZulipTestSummaryNotification with job fails and no test results"() {
-        setup:
-        groovyScript.getBinding().setVariable("BUILD_URL", 'URL/')
-        groovyScript.getBinding().setVariable("BUILD_NUMBER", '256')
-        def jobMock = [ result: 'FAILURE' ]
-        def testResultsMock = [ passCount: 254, failCount: 635 ]
-        def failedTestsMock = [ [ fullName: 'FULL_NAME1', url: 'FIRST_TEST_URL' ], [ fullName: 'FULL_NAME2', url: 'SECOND_TEST_URL' ]]
-        when:
-        groovyScript.sendZulipTestSummaryNotification('SUBJECT', ['email@anything.com'])
-        then:
-        1 * getPipelineMock("util.retrieveArtifact")(['console.log', 'URL/']) >> ''
-        1 * getPipelineMock("util.retrieveConsoleLog")([100, 'URL/']) >> 'this is the console'
-        1 * getPipelineMock("util.retrieveJobInformation")('URL/') >> jobMock
-        1 * getPipelineMock('util.isJobResultSuccess')('FAILURE') >> false
-        1 * getPipelineMock("util.retrieveTestResults")('URL/') >> { throw new Exception('no results') }
-        0 * getPipelineMock("util.retrieveFailedTests")('URL/') >> failedTestsMock
-        1 * getPipelineMock('emailext')([ subject: 'SUBJECT', to: 'email@anything.com', body: '''
-**Deploy job** #256 was: **FAILURE**
-Possible explanation: Pipeline failure or project build failure
-
-
-Please look here: URL/ or see console log:
-
-```spoiler Logs
-this is the console
-```
-'''
-        ])
-    }
-
-    def "[mailer.groovy] sendZulipTestSummaryNotification with no failed tests"() {
-        setup:
-        groovyScript.getBinding().setVariable("BUILD_URL", 'URL/')
-        groovyScript.getBinding().setVariable("BUILD_NUMBER", '256')
-        def jobMock = [ result: 'FAILURE' ]
-        def testResultsMock = [ passCount: 254, failCount: 635 ]
-        when:
-        groovyScript.sendZulipTestSummaryNotification('SUBJECT', ['email@anything.com'])
-        then:
-        1 * getPipelineMock("util.retrieveArtifact")(['console.log', 'URL/']) >> ''
-        1 * getPipelineMock("util.retrieveConsoleLog")([100, 'URL/']) >> 'this is the console'
-        1 * getPipelineMock("util.retrieveJobInformation")('URL/') >> jobMock
-        1 * getPipelineMock('util.isJobResultSuccess')('FAILURE') >> false
-        1 * getPipelineMock("util.retrieveTestResults")('URL/') >> testResultsMock
-        1 * getPipelineMock("util.retrieveFailedTests")('URL/') >> []
-        1 * getPipelineMock('emailext')([ subject: 'SUBJECT', to: 'email@anything.com', body: '''
-**Deploy job** #256 was: **FAILURE**
-Possible explanation: Pipeline failure or project build failure
-
-
-**Test results:**
-- PASSED: 254
-- FAILED: 635
-
-Those are the test failures: none
-
-
-Please look here: URL/ or see console log:
-
-```spoiler Logs
-this is the console
-```
-'''
-        ])
+        1 * getPipelineMock('util.getMarkdownTestSummary')('JOB_ID', 'URL/') >> 'CONTENT'
+        1 * getPipelineMock('emailext')([ subject: 'SUBJECT', to: 'email@anything.com,email@otherthing.com', body: 'CONTENT'])
     }
 
 }

--- a/test/vars/UtilSpec.groovy
+++ b/test/vars/UtilSpec.groovy
@@ -731,21 +731,21 @@ class UtilSpec extends JenkinsPipelineSpecification {
         result == 'CONTENT'
     }
 
-    def "[util.groovy] retrieveConsoleLog with build url"() {
+    def "[util.groovy] retrieveConsoleLog with number of lines"() {
         setup:
         groovyScript.getBinding().setVariable('BUILD_URL', 'URL/')
         when:
-        def result = groovyScript.retrieveConsoleLog("BUILD_URL/")
+        def result = groovyScript.retrieveConsoleLog(3)
         then:
-        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - BUILD_URL/consoleText | tail -n 750']) >> 'CONTENT'
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - URL/consoleText | tail -n 3']) >> 'CONTENT'
         result == 'CONTENT'
     }
 
-    def "[util.groovy] retrieveConsoleLog with build url and number of lines"() {
+    def "[util.groovy] retrieveConsoleLog with number of lines and build url"() {
         setup:
         groovyScript.getBinding().setVariable('BUILD_URL', 'URL/')
         when:
-        def result = groovyScript.retrieveConsoleLog("BUILD_URL/", 2)
+        def result = groovyScript.retrieveConsoleLog(2, "BUILD_URL/")
         then:
         1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - BUILD_URL/consoleText | tail -n 2']) >> 'CONTENT'
         result == 'CONTENT'

--- a/test/vars/UtilSpec.groovy
+++ b/test/vars/UtilSpec.groovy
@@ -884,7 +884,7 @@ class UtilSpec extends JenkinsPipelineSpecification {
                         ],
                         [
                             status: 'SKIPPED',
-                            className: 'package1.class2.',
+                            className: 'package1.class2',
                             name: 'test'
                         ]
                     ]
@@ -991,7 +991,7 @@ class UtilSpec extends JenkinsPipelineSpecification {
         result.url == 'ANY_URL'
     }
 
-        def "[util.groovy] retrieveJobInformation with build url"() {
+    def "[util.groovy] retrieveJobInformation with build url"() {
         setup:
         groovyScript.getBinding().setVariable('BUILD_URL', 'URL/')
         def jobMock = [
@@ -1003,5 +1003,348 @@ class UtilSpec extends JenkinsPipelineSpecification {
         1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - BUILD_URL/api/json']) >> 'CONTENT'
         1 * getPipelineMock('readJSON')([text: 'CONTENT']) >> jobMock
         result.url == 'ANY_URL'
+    }
+
+    def "[util.groovy] getMarkdownTestSummary with no build url and job success"() {
+        setup:
+        groovyScript.getBinding().setVariable("BUILD_URL", 'URL/')
+        groovyScript.getBinding().setVariable("BUILD_NUMBER", '256')
+        def jobMock = [ result: 'SUCCESS' ]
+        when:
+        def result = groovyScript.getMarkdownTestSummary('JOB_ID')
+        then:
+        // retrieveArtifact
+        1 * getPipelineMock('sh')([returnStdout: true, script: "curl -o /dev/null --silent -Iw '%{http_code}' URL/artifact/console.log"]) >> '200'
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - URL/artifact/console.log']) >> ''
+        // retrieveConsoleLog
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - URL/consoleText | tail -n 100']) >> 'this is the console'
+        // retrieveJobInformation
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - URL/api/json']) >> 'CONTENT'
+        1 * getPipelineMock('readJSON')([text: 'CONTENT']) >> jobMock
+
+        // check result
+        result == '''
+**JOB_ID job** #256 was: **SUCCESS**
+'''
+    }
+
+    def "[util.groovy] getMarkdownTestSummary with build url, job success"() {
+        setup:
+        groovyScript.getBinding().setVariable("BUILD_URL", 'URL/')
+        groovyScript.getBinding().setVariable("BUILD_NUMBER", '256')
+        def jobMock = [ result: 'SUCCESS' ]
+        when:
+        def result = groovyScript.getMarkdownTestSummary('JOB_ID', 'BUILD_URL/')
+        then:
+        // retrieveArtifact
+        1 * getPipelineMock('sh')([returnStdout: true, script: "curl -o /dev/null --silent -Iw '%{http_code}' BUILD_URL/artifact/console.log"]) >> '200'
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - BUILD_URL/artifact/console.log']) >> ''
+        // retrieveConsoleLog
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - BUILD_URL/consoleText | tail -n 100']) >> 'this is the console'
+        // retrieveJobInformation
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - BUILD_URL/api/json']) >> 'CONTENT'
+        1 * getPipelineMock('readJSON')([text: 'CONTENT']) >> jobMock
+
+        // check result
+        result == '''
+**JOB_ID job** #256 was: **SUCCESS**
+'''
+    }
+
+    def "[util.groovy] getMarkdownTestSummary with job fails"() {
+        setup:
+        groovyScript.getBinding().setVariable("BUILD_URL", 'URL/')
+        groovyScript.getBinding().setVariable("BUILD_NUMBER", '256')
+        def jobMock = [ result: 'FAILURE' ]
+        def testResultsMock = [ passCount: 254, failCount: 635 ]
+        def failedTestsMock = [ 
+            suites: [ 
+                [ 
+                    cases: [
+                        [
+                            status: 'FAILED',
+                            className: 'package1.class1',
+                            name: 'test'
+                        ],
+                        [
+                            status: 'FAILED',
+                            className: 'package1.class2',
+                            name: 'test'
+                        ]
+                    ]
+                ]
+            ]
+        ]
+        when:
+        def result = groovyScript.getMarkdownTestSummary('JOB_ID')
+        then:
+        // retrieveArtifact
+        1 * getPipelineMock('sh')([returnStdout: true, script: "curl -o /dev/null --silent -Iw '%{http_code}' URL/artifact/console.log"]) >> '200'
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - URL/artifact/console.log']) >> ''
+        // retrieveConsoleLog
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - URL/consoleText | tail -n 100']) >> 'this is the console'
+        // retrieveJobInformation
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - URL/api/json']) >> 'JOB_INFO'
+        1 * getPipelineMock('readJSON')([text: 'JOB_INFO']) >> jobMock
+        // retrieveTestResults
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - URL/testReport/api/json']) >> 'TEST_RESULTS'
+        1 * getPipelineMock('readJSON')([text: 'TEST_RESULTS']) >> testResultsMock
+        // retrieveFailedTests
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - URL/testReport/api/json']) >> 'FAILED_TESTS'
+        1 * getPipelineMock('readJSON')([text: 'FAILED_TESTS']) >> failedTestsMock
+
+        // check result
+        result == '''
+**JOB_ID job** #256 was: **FAILURE**
+Possible explanation: Pipeline failure or project build failure
+
+
+**Test results:**
+- PASSED: 254
+- FAILED: 635
+
+Those are the test failures: 
+- [package1.class1.test](URL/testReport/package1/class1/test/)
+- [package1.class2.test](URL/testReport/package1/class2/test/)
+
+
+Please look here: URL/ or see console log:
+
+```spoiler Logs
+this is the console
+```
+'''
+    }
+
+    def "[util.groovy] getMarkdownTestSummary with job fails and build url"() {
+        setup:
+        groovyScript.getBinding().setVariable("BUILD_URL", 'URL/')
+        groovyScript.getBinding().setVariable("BUILD_NUMBER", '256')
+        def jobMock = [ result: 'FAILURE' ]
+        def testResultsMock = [ passCount: 254, failCount: 635 ]
+        def failedTestsMock = [ 
+            suites: [ 
+                [ 
+                    cases: [
+                        [
+                            status: 'FAILED',
+                            className: 'package1.class1',
+                            name: 'test'
+                        ],
+                        [
+                            status: 'FAILED',
+                            className: 'package1.class2',
+                            name: 'test'
+                        ]
+                    ]
+                ]
+            ]
+        ]
+        when:
+        def result = groovyScript.getMarkdownTestSummary('JOB_ID', 'BUILD_URL/')
+        then:
+        // retrieveArtifact
+        1 * getPipelineMock('sh')([returnStdout: true, script: "curl -o /dev/null --silent -Iw '%{http_code}' BUILD_URL/artifact/console.log"]) >> '200'
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - BUILD_URL/artifact/console.log']) >> ''
+        // retrieveConsoleLog
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - BUILD_URL/consoleText | tail -n 100']) >> 'this is the console'
+        // retrieveJobInformation
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - BUILD_URL/api/json']) >> 'JOB_INFO'
+        1 * getPipelineMock('readJSON')([text: 'JOB_INFO']) >> jobMock
+        // retrieveTestResults
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - BUILD_URL/testReport/api/json']) >> 'TEST_RESULTS'
+        1 * getPipelineMock('readJSON')([text: 'TEST_RESULTS']) >> testResultsMock
+        // retrieveFailedTests
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - BUILD_URL/testReport/api/json']) >> 'FAILED_TESTS'
+        1 * getPipelineMock('readJSON')([text: 'FAILED_TESTS']) >> failedTestsMock
+
+        // check result
+        result == '''
+**JOB_ID job** #256 was: **FAILURE**
+Possible explanation: Pipeline failure or project build failure
+
+
+**Test results:**
+- PASSED: 254
+- FAILED: 635
+
+Those are the test failures: 
+- [package1.class1.test](BUILD_URL/testReport/package1/class1/test/)
+- [package1.class2.test](BUILD_URL/testReport/package1/class2/test/)
+
+
+Please look here: BUILD_URL/ or see console log:
+
+```spoiler Logs
+this is the console
+```
+'''
+    }
+
+    def "[util.groovy] getMarkdownTestSummary with job fails and console artifact existing"() {
+        setup:
+        groovyScript.getBinding().setVariable("BUILD_URL", 'URL/')
+        groovyScript.getBinding().setVariable("BUILD_NUMBER", '256')
+        def jobMock = [ result: 'FAILURE' ]
+        def testResultsMock = [ passCount: 254, failCount: 635 ]
+        def failedTestsMock = [ 
+            suites: [ 
+                [ 
+                    cases: [
+                        [
+                            status: 'FAILED',
+                            className: 'package1.class1',
+                            name: 'test'
+                        ],
+                        [
+                            status: 'FAILED',
+                            className: 'package1.class2',
+                            name: 'test'
+                        ]
+                    ]
+                ]
+            ]
+        ]
+        when:
+        def result = groovyScript.getMarkdownTestSummary('JOB_ID')
+        then:
+        // retrieveArtifact
+        1 * getPipelineMock('sh')([returnStdout: true, script: "curl -o /dev/null --silent -Iw '%{http_code}' URL/artifact/console.log"]) >> '200'
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - URL/artifact/console.log']) >> 'this is the console artifact'
+        // retrieveConsoleLog
+        0 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - URL/consoleText | tail -n 100']) >> 'this is the console'
+        // retrieveJobInformation
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - URL/api/json']) >> 'JOB_INFO'
+        1 * getPipelineMock('readJSON')([text: 'JOB_INFO']) >> jobMock
+        // retrieveTestResults
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - URL/testReport/api/json']) >> 'TEST_RESULTS'
+        1 * getPipelineMock('readJSON')([text: 'TEST_RESULTS']) >> testResultsMock
+        // retrieveFailedTests
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - URL/testReport/api/json']) >> 'FAILED_TESTS'
+        1 * getPipelineMock('readJSON')([text: 'FAILED_TESTS']) >> failedTestsMock
+
+        // check result
+        result == '''
+**JOB_ID job** #256 was: **FAILURE**
+Possible explanation: Pipeline failure or project build failure
+
+
+**Test results:**
+- PASSED: 254
+- FAILED: 635
+
+Those are the test failures: 
+- [package1.class1.test](URL/testReport/package1/class1/test/)
+- [package1.class2.test](URL/testReport/package1/class2/test/)
+
+
+Please look here: URL/ or see console log:
+
+```spoiler Logs
+this is the console artifact
+```
+'''
+    }
+
+    def "[util.groovy] getMarkdownTestSummary with job fails and no test results"() {
+        setup:
+        groovyScript.getBinding().setVariable("BUILD_URL", 'URL/')
+        groovyScript.getBinding().setVariable("BUILD_NUMBER", '256')
+        def jobMock = [ result: 'FAILURE' ]
+        def testResultsMock = [ passCount: 254, failCount: 635 ]
+        def failedTestsMock = [ 
+            suites: [ 
+                [ 
+                    cases: [
+                        [
+                            status: 'FAILED',
+                            className: 'package1.class1',
+                            name: 'test'
+                        ],
+                        [
+                            status: 'FAILED',
+                            className: 'package1.class2',
+                            name: 'test'
+                        ]
+                    ]
+                ]
+            ]
+        ]
+        when:
+        def result = groovyScript.getMarkdownTestSummary('JOB_ID')
+        then:
+        // retrieveArtifact
+        1 * getPipelineMock('sh')([returnStdout: true, script: "curl -o /dev/null --silent -Iw '%{http_code}' URL/artifact/console.log"]) >> '200'
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - URL/artifact/console.log']) >> ''
+        // retrieveConsoleLog
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - URL/consoleText | tail -n 100']) >> 'this is the console'
+        // retrieveJobInformation
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - URL/api/json']) >> 'JOB_INFO'
+        1 * getPipelineMock('readJSON')([text: 'JOB_INFO']) >> jobMock
+        // retrieveTestResults
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - URL/testReport/api/json']) >> { throw new Exception('unknown URL') }
+        0 * getPipelineMock('readJSON')([text: 'TEST_RESULTS']) >> testResultsMock
+        // retrieveFailedTests
+        0 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - URL/testReport/api/json']) >> 'FAILED_TESTS'
+        0 * getPipelineMock('readJSON')([text: 'FAILED_TESTS']) >> failedTestsMock
+
+        // check result
+        result == '''
+**JOB_ID job** #256 was: **FAILURE**
+Possible explanation: Pipeline failure or project build failure
+
+
+Please look here: URL/ or see console log:
+
+```spoiler Logs
+this is the console
+```
+'''
+    }
+
+    def "[util.groovy] getMarkdownTestSummary with job fails with no failed tests"() {
+        setup:
+        groovyScript.getBinding().setVariable("BUILD_URL", 'URL/')
+        groovyScript.getBinding().setVariable("BUILD_NUMBER", '256')
+        def jobMock = [ result: 'FAILURE' ]
+        def testResultsMock = [ passCount: 254, failCount: 635 ]
+        def failedTestsMock = [:]
+        when:
+        def result = groovyScript.getMarkdownTestSummary('JOB_ID')
+        then:
+        // retrieveArtifact
+        1 * getPipelineMock('sh')([returnStdout: true, script: "curl -o /dev/null --silent -Iw '%{http_code}' URL/artifact/console.log"]) >> '200'
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - URL/artifact/console.log']) >> ''
+        // retrieveConsoleLog
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - URL/consoleText | tail -n 100']) >> 'this is the console'
+        // retrieveJobInformation
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - URL/api/json']) >> 'JOB_INFO'
+        1 * getPipelineMock('readJSON')([text: 'JOB_INFO']) >> jobMock
+        // retrieveTestResults
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - URL/testReport/api/json']) >> 'TEST_RESULTS'
+        1 * getPipelineMock('readJSON')([text: 'TEST_RESULTS']) >> testResultsMock
+        // retrieveFailedTests
+        1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - URL/testReport/api/json']) >> 'FAILED_TESTS'
+        1 * getPipelineMock('readJSON')([text: 'FAILED_TESTS']) >> failedTestsMock
+
+        // check result
+        result == '''
+**JOB_ID job** #256 was: **FAILURE**
+Possible explanation: Pipeline failure or project build failure
+
+
+**Test results:**
+- PASSED: 254
+- FAILED: 635
+
+Those are the test failures: none
+
+
+Please look here: URL/ or see console log:
+
+```spoiler Logs
+this is the console
+```
+'''
     }
 }

--- a/vars/mailer.groovy
+++ b/vars/mailer.groovy
@@ -15,7 +15,7 @@ def sendEmail_failedPR(String additionalSubject = null ) {
                    Failed tests \${TEST_COUNTS,var=\"fail\"}: ${BUILD_URL}testReport
                    (IMPORTANT: For visiting the links you need to have access to Red Hat VPN. In case you don\'t have access to RedHat VPN please download and decompress attached file.)
                    """,
-            attachmentsPattern: "error.log.gz",
+            attachmentsPattern: 'error.log.gz',
             recipientProviders: [[$class: 'DevelopersRecipientProvider'], [$class: 'RequesterRecipientProvider']])
 }
 
@@ -36,14 +36,14 @@ def sendEmail_unstablePR(String additionalSubject = null ) {
 def sendEmail_fixedPR(String additionalSubject = null ) {
     emailext(
             subject: "${additionalSubject?.trim() || additionalSubject?.trim() != null ? additionalSubject?.trim() : 'PR'} #$ghprbPullId of $ghprbGhRepository: $ghprbPullTitle is fixed and was SUCCESSFUL",
-            body: "",
+            body: '',
             recipientProviders: [[$class: 'DevelopersRecipientProvider'], [$class: 'RequesterRecipientProvider']])
 }
 
 def sendEmail_abortedPR(String additionalSubject = null ) {
     emailext(
             subject: "${additionalSubject?.trim() || additionalSubject?.trim() != null ? additionalSubject?.trim() : 'PR'} #$ghprbPullId of $ghprbGhRepository: $ghprbPullTitle was ABORTED",
-            body: "",
+            body: '',
             recipientProviders: [[$class: 'DevelopersRecipientProvider'], [$class: 'RequesterRecipientProvider']])
 }
 
@@ -54,5 +54,64 @@ def buildLogScriptPR () {
         sh 'echo "wget --no-check-certificate ${BUILD_URL}consoleText" >> trace.sh'
         sh 'echo "tail -n 750 consoleText >> error.log" >> trace.sh'
         sh 'echo "gzip error.log" >> trace.sh'
+    }
+}
+
+void sendZulipTestSummaryNotification(String subject, List recipients, String buildUrl = "${BUILD_URL}") {
+    // Check if console.log is available as artifact first
+    String consoleLog = util.retrieveArtifact('console.log', buildUrl)
+    consoleLog = consoleLog ?: util.retrieveConsoleLog(100, buildUrl)
+
+    String jobResult = util.retrieveJobInformation(buildUrl).result
+    String body = """
+**Deploy job** #${BUILD_NUMBER} was: **${jobResult}**
+"""
+
+    if (!util.isJobResultSuccess(jobResult)) {
+        body += "Possible explanation: ${getErrorExplanationMessage(jobResult)}\n"
+
+        try {
+            def testResults = util.retrieveTestResults(buildUrl)
+            def failedTests = util.retrieveFailedTests(buildUrl)
+
+            body += """
+\n**Test results:**
+- PASSED: ${testResults.passCount}
+- FAILED: ${testResults.failCount}
+
+Those are the test failures: ${failedTests.size() <= 0 ? 'none' : '\n'}${failedTests.collect { failedTest ->
+                return "- [${failedTest.fullName}](${failedTest.url})"
+}.join('\n')}
+"""
+        } catch (err) {
+            echo 'No test results found'
+        }
+
+        body += """
+\nPlease look here: ${buildUrl} or see console log:
+
+```spoiler Logs
+${consoleLog}
+```
+"""
+    }
+
+    emailext subject: subject,
+            to: recipients.join(','),
+            body: body
+}
+
+String getErrorExplanationMessage(String jobResult) {
+    switch (jobResult) {
+        case 'SUCCESS':
+            return 'Do I need to explain ?'
+        case 'UNSTABLE':
+            return 'This should be test failures'
+        case 'FAILURE':
+            return 'Pipeline failure or project build failure'
+        case 'ABORTED':
+            return 'Most probably a timeout, please review'
+        default:
+            return 'Woops ... I don\'t know about this result value ... Please ask maintainer.'
     }
 }

--- a/vars/mailer.groovy
+++ b/vars/mailer.groovy
@@ -68,7 +68,7 @@ void sendZulipTestSummaryNotification(String subject, List recipients, String bu
 """
 
     if (!util.isJobResultSuccess(jobResult)) {
-        body += "Possible explanation: ${getErrorExplanationMessage(jobResult)}\n"
+        body += "Possible explanation: ${getResultExplanationMessage(jobResult)}\n"
 
         try {
             def testResults = util.retrieveTestResults(buildUrl)
@@ -101,7 +101,7 @@ ${consoleLog}
             body: body
 }
 
-String getErrorExplanationMessage(String jobResult) {
+String getResultExplanationMessage(String jobResult) {
     switch (jobResult) {
         case 'SUCCESS':
             return 'Do I need to explain ?'

--- a/vars/util.groovy
+++ b/vars/util.groovy
@@ -353,8 +353,14 @@ def rmPartialDeps(){
     }
 }
 
-String retrieveConsoleLog(int numberOfLines = 750, String buildUrl = "${BUILD_URL}") {
+String retrieveConsoleLog(int numberOfLines = 100, String buildUrl = "${BUILD_URL}") {
     return sh(returnStdout: true, script: "wget --no-check-certificate -qO - ${buildUrl}consoleText | tail -n ${numberOfLines}")
+}
+
+String archiveConsoleLog(int numberOfLines = 100, String buildUrl = "${BUILD_URL}") {
+    sh 'rm -rf console.log'
+    writeFile(text: retrieveConsoleLog(numberOfLines, buildUrl), file: 'console.log')
+    archiveArtifacts(artifacts: 'console.log')
 }
 
 def retrieveTestResults(String buildUrl = "${BUILD_URL}") {

--- a/vars/util.groovy
+++ b/vars/util.groovy
@@ -353,7 +353,7 @@ def rmPartialDeps(){
     }
 }
 
-String retrieveConsoleLog(String buildUrl = "${BUILD_URL}", int numberOfLines = 750) {
+String retrieveConsoleLog(int numberOfLines = 750, String buildUrl = "${BUILD_URL}") {
     return sh(returnStdout: true, script: "wget --no-check-certificate -qO - ${buildUrl}consoleText | tail -n ${numberOfLines}")
 }
 
@@ -367,7 +367,7 @@ def retrieveFailedTests(String buildUrl = "${BUILD_URL}") {
     def failedTests = []
     testResults.suites.each { testSuite ->
         testSuite.cases.each { testCase ->
-            if (testCase.status != 'PASSED' && testCase.status != 'SKIPPED') {
+            if (testCase.status != 'PASSED' && testCase.status != 'SKIPPED' && testCase.status != 'FIXED') {
                 def failedTest = [:]
                 failedTest.status = testCase.status
 
@@ -376,7 +376,7 @@ def retrieveFailedTests(String buildUrl = "${BUILD_URL}") {
                 int lastIndexOf = fullClassName.lastIndexOf('.')
                 packageName = fullClassName.substring(0, lastIndexOf)
                 className = fullClassName.substring(lastIndexOf + 1)
-                
+
                 failedTest.name = testCase.name
                 failedTest.packageName = packageName
                 failedTest.className = className
@@ -400,4 +400,20 @@ String retrieveArtifact(String artifactPath, String buildUrl = "${BUILD_URL}") {
 
 def retrieveJobInformation(String buildUrl = "${BUILD_URL}") {
     return readJSON(text: sh(returnStdout: true, script: "wget --no-check-certificate -qO - ${buildUrl}api/json"))
+}
+
+boolean isJobResultSuccess(String jobResult) {
+    return jobResult == 'SUCCESS'
+}
+
+boolean isJobResultFailure(String jobResult) {
+    return jobResult == 'FAILURE'
+}
+
+boolean isJobResultAborted(String jobResult) {
+    return jobResult == 'ABORTED'
+}
+
+boolean isJobResultUnstable(String jobResult) {
+    return jobResult == 'UNSTABLE'
 }

--- a/vars/util.groovy
+++ b/vars/util.groovy
@@ -373,7 +373,7 @@ def retrieveFailedTests(String buildUrl = "${BUILD_URL}") {
     def failedTests = []
     testResults.suites?.each { testSuite ->
         testSuite.cases?.each { testCase ->
-            if (testCase.status != 'PASSED' && testCase.status != 'SKIPPED' && testCase.status != 'FIXED') {
+            if (!['PASSED', 'SKIPPED', 'FIXED'].contains(testCase.status)) {
                 def failedTest = [:]
                 failedTest.status = testCase.status
 


### PR DESCRIPTION
This will get all info from Jenkins to display job result and test reports if failure/unstable, also get console logs (either from a console.log artifact if existing or directly from the console log)

This is formatting for Zulip (aka Markdown)

Examples of messages can be found in https://kie.zulipchat.com/#narrow/stream/236603-kogito-ci/topic/.5Btest.5D.20Test.20display.20failed.20tests