### PR TITLE
Remove automatic id for util.archiveConsoleLog

### DIFF
--- a/test/vars/UtilSpec.groovy
+++ b/test/vars/UtilSpec.groovy
@@ -756,24 +756,18 @@ class UtilSpec extends JenkinsPipelineSpecification {
     def "[util.groovy] archiveConsoleLog no arg"() {
         setup:
         groovyScript.getBinding().setVariable('BUILD_URL', 'URL/')
-        groovyScript.metaClass.generateHash = { int size ->
-            return 'GENERATED_ID'
-        }
         when:
         def result = groovyScript.archiveConsoleLog()
         then:
-        1 * getPipelineMock('sh')('rm -rf GENERATED_ID_console.log')
+        1 * getPipelineMock('sh')('rm -rf console.log')
         1 * getPipelineMock('sh')([returnStdout: true, script: 'wget --no-check-certificate -qO - URL/consoleText | tail -n 100']) >> 'CONTENT'
-        1 * getPipelineMock('writeFile')([text: 'CONTENT', file: 'GENERATED_ID_console.log'])
-        1 * getPipelineMock('archiveArtifacts.call')([artifacts: 'GENERATED_ID_console.log'])
+        1 * getPipelineMock('writeFile')([text: 'CONTENT', file: 'console.log'])
+        1 * getPipelineMock('archiveArtifacts.call')([artifacts: 'console.log'])
     }
 
     def "[util.groovy] archiveConsoleLog  with id"() {
         setup:
         groovyScript.getBinding().setVariable('BUILD_URL', 'URL/')
-        groovyScript.metaClass.generateHash = { int size ->
-            return 'GENERATED_ID'
-        }
         when:
         def result = groovyScript.archiveConsoleLog('ID', 3)
         then:

--- a/vars/util.groovy
+++ b/vars/util.groovy
@@ -357,8 +357,8 @@ String retrieveConsoleLog(int numberOfLines = 100, String buildUrl = "${BUILD_UR
     return sh(returnStdout: true, script: "wget --no-check-certificate -qO - ${buildUrl}consoleText | tail -n ${numberOfLines}")
 }
 
-String archiveConsoleLog(String id = generateHash(10), int numberOfLines = 100, String buildUrl = "${BUILD_URL}") {
-    String filename = "${id}_console.log"
+String archiveConsoleLog(String id = '', int numberOfLines = 100, String buildUrl = "${BUILD_URL}") {
+    String filename = "${id ? "${id}_" : ''}console.log"
     sh "rm -rf ${filename}"
     writeFile(text: retrieveConsoleLog(numberOfLines, buildUrl), file: filename)
     archiveArtifacts(artifacts: filename)


### PR DESCRIPTION
This has no added value.
In that way we can also override the default `console.log` file created if no id is given.

This will NOT have any impact on current jobs using it.