### PR TITLE
Do not turn build number into a GH issue/PR link

### DIFF
--- a/test/vars/UtilSpec.groovy
+++ b/test/vars/UtilSpec.groovy
@@ -1653,7 +1653,7 @@ Please look here: URL/display/redirect'''
 
         // check result
         result == '''
-**JOB_ID job** #256 was: **FAILURE**
+**JOB_ID job** `#256` was: **FAILURE**
 Possible explanation: Pipeline failure or project build failure
 
 

--- a/vars/util.groovy
+++ b/vars/util.groovy
@@ -472,7 +472,7 @@ String getMarkdownTestSummary(String jobId = '', String additionalInfo = '', Str
 
     String jobResult = jobInfo.result
     String summary = """
-${jobId ? "**${jobId} job**" : 'Job'} #${BUILD_NUMBER} was: **${jobResult}**
+${jobId ? "**${jobId} job**" : 'Job'} ${formatBuildNumber(outputStyle, BUILD_NUMBER)} was: **${jobResult}**
 """
 
     if (!isJobResultSuccess(jobResult)) {
@@ -559,4 +559,8 @@ String getResultExplanationMessage(String jobResult) {
 
 String formatTextForHtmlDisplay(String text) {
     return text.replaceAll('\n', '<br/>')
+}
+
+String formatBuildNumber(String outputStyle, String buildNumber) {
+    return 'GITHUB'.equalsIgnoreCase(outputStyle) ? "`#${buildNumber}`" : "#${buildNumber}"
 }


### PR DESCRIPTION
I noticed that kie-ci1 bot started posting comments with details about failed Jenkins jobs on GitHub PRs. There's a small problem. The comment contains the build number prefixed with `#` which unexpectedly turns it into a link to another GitHub PR or issue. That creates unwanted noise.