### PR TITLE
[BXMSPROD-1802] Ignore jiras not matching CVE template

### DIFF
--- a/test/resources/jira-cve-type.json
+++ b/test/resources/jira-cve-type.json
@@ -153,6 +153,16 @@
         "summary": "CVE-2020-25649 jackson-databind: FasterXML DOMDeserializer insecure entity expansion is vulnerable to XML external entity (XXE) [rhpam-7]",
         "description": "Security Tracking Issue\n\nDo not make this issue public.\n\nImpact: Low\n Public Date: 09-Jan-2020\n Resolve Bug By: 07-Jul-2021\n\nIn case the dates above are already past, please evaluate this bug in your next prioritization review and make a decision then.\n\nPlease see the Security Errata Policy for further details: [https://docs.engineering.redhat.com/x/9RBqB]\n\nFlaw:\n----\nCVE-2020-25649 jackson-databind: FasterXML DOMDeserializer insecure entity expansion is vulnerable to XML external entity (XXE)\n [https://bugzilla.redhat.com/show_bug.cgi?id=1887664]\n\nA flaw was found in FasterXML Jackson Databind which did not have entity expansion secured properly making it vulnerable to XML external entity (XXE). This vulnerability is similar to CVE-2019-10172. The primary threat from this flaw is data integrity."
       }
+    },
+    {
+      "expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
+      "id": "14777618",
+      "self": "https://issues.redhat.com/rest/api/2/issue/14777618",
+      "key": "RHPAM-4470",
+      "fields": {
+        "summary": "PIM needs sanitation for input characters",
+        "description": "It may be possible  to execute arbitrary code on the Web application's clients, so sanitation of hazardous characters should be performed correctly on user input."
+      }
     }
   ]
 }

--- a/test/vars/RhsaErrataSpec.groovy
+++ b/test/vars/RhsaErrataSpec.groovy
@@ -9,6 +9,7 @@ class RhsaErrataSpec extends JenkinsPipelineSpecification {
     def bugzillaLink = null
 
     def setup() {
+        explicitlyMockPipelineVariable("out")
         groovyScript = loadPipelineScriptForTest('vars/rhsaErrata.groovy')
         cveJson = new File(getClass().getResource('/jira-cve-type.json').toURI()).text
         def resultMap = new JsonSlurper().parseText(cveJson)

--- a/vars/rhsaErrata.groovy
+++ b/vars/rhsaErrata.groovy
@@ -38,8 +38,7 @@ def getCVEList(String cveJson, String bzLink) {
                 cve.problemDescription = getProblemDescription(summary)
                 cveList.add(cve)
             } catch(Exception e) {
-                println "[ERROR] Unable to extract information: ${e.getStackTrace()}."
-                println "[WARNING] Skipping jira ${jiraNumber}.."
+                println "[WARNING] Skipping Jira ${jiraNumber} since the Jira description doesn't match the expected format. Note that as a CVE number is present in the Jira summary, we should double-check if this Jira should be included."
             }
         } else {
             println "[INFO] Skipping Jira ${jiraNumber} since the Jira summary doesn't match the expected format."

--- a/vars/rhsaErrata.groovy
+++ b/vars/rhsaErrata.groovy
@@ -28,22 +28,21 @@ def getCVEList(String cveJson, String bzLink) {
         def description = resultMap.issues.fields.description[index]
 
         // skip an issue if not matching CVE template: summary starting with 'CVE-XXXX..'
-        if (!summary.trim().startsWith("CVE-")) {
+        if (summary.trim().startsWith("CVE")) {
+            try {
+                def cve = new CVE()
+                cve.name = getCVENumber(summary)
+                cve.impact = getCVEImpact(description)
+                cve.jiraNumber = jiraNumber
+                cve.bzNumber = getBZNumber(description, bzLink)
+                cve.problemDescription = getProblemDescription(summary)
+                cveList.add(cve)
+            } catch(Exception e) {
+                println "[ERROR] Unable to extract information: ${e.getStackTrace()}."
+                println "[WARNING] Skipping jira ${jiraNumber}.."
+            }
+        } else {
             println "[INFO] Skipping jira ${jiraNumber} since not matching CVE template."
-            return
-        }
-
-        try {
-            def cve = new CVE()
-            cve.name = getCVENumber(summary)
-            cve.impact = getCVEImpact(description)
-            cve.jiraNumber = jiraNumber
-            cve.bzNumber = getBZNumber(description, bzLink)
-            cve.problemDescription = getProblemDescription(summary)
-            cveList.add(cve)
-        } catch(Exception e) {
-            println "[ERROR] Unable to extract information: ${e.getStackTrace()}."
-            println "[WARNING] Skipping jira ${jiraNumber}.."
         }
     }
     return cveList

--- a/vars/rhsaErrata.groovy
+++ b/vars/rhsaErrata.groovy
@@ -42,7 +42,7 @@ def getCVEList(String cveJson, String bzLink) {
                 println "[WARNING] Skipping jira ${jiraNumber}.."
             }
         } else {
-            println "[INFO] Skipping jira ${jiraNumber} since not matching CVE template."
+            println "[INFO] Skipping Jira ${jiraNumber} since the Jira summary doesn't match the expected format."
         }
     }
     return cveList

--- a/vars/rhsaErrata.groovy
+++ b/vars/rhsaErrata.groovy
@@ -27,13 +27,24 @@ def getCVEList(String cveJson, String bzLink) {
         def summary = resultMap.issues.fields.summary[index]
         def description = resultMap.issues.fields.description[index]
 
-        def cve = new CVE()
-        cve.name = getCVENumber(summary)
-        cve.impact = getCVEImpact(description)
-        cve.jiraNumber = jiraNumber
-        cve.bzNumber = getBZNumber(description, bzLink)
-        cve.problemDescription = getProblemDescription(summary)
-        cveList.add(cve)
+        // skip an issue if not matching CVE template: summary starting with 'CVE-XXXX..'
+        if (!summary.trim().startsWith("CVE-")) {
+            println "[INFO] Skipping jira ${jiraNumber} since not matching CVE template."
+            return
+        }
+
+        try {
+            def cve = new CVE()
+            cve.name = getCVENumber(summary)
+            cve.impact = getCVEImpact(description)
+            cve.jiraNumber = jiraNumber
+            cve.bzNumber = getBZNumber(description, bzLink)
+            cve.problemDescription = getProblemDescription(summary)
+            cveList.add(cve)
+        } catch(Exception e) {
+            println "[ERROR] Unable to extract information: ${e.getStackTrace()}."
+            println "[WARNING] Skipping jira ${jiraNumber}.."
+        }
     }
     return cveList
 }


### PR DESCRIPTION
**Jira**:
- https://issues.redhat.com/browse/BXMSPROD-1802

Fixes on **rhsaErrata**: 
- Ignore those jiras that do not match the CVE template, i.e., those that do not start with 'CVE-...'
- Added try-catch such that if something went wrong extracting needed information, only that jira will be skipped