### PR TITLE
bumped up com.synopsys.jenkinsci:ownership

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -636,7 +636,7 @@
         <dependency>
             <groupId>com.synopsys.jenkinsci</groupId>
             <artifactId>ownership</artifactId>
-            <version>0.12.1</version>
+            <version>0.2.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
due to [dependabot alerts](https://github.com/kiegroup/jenkins-pipeline-shared-libraries/security/dependabot/160) 
com.synopsys.jenkinsci:ownership had to been upgraded to the next version of 1.13.0