### PR TITLE
[BXMSPROD-1981] Add method to export bacon build config

### DIFF
--- a/test/resources/nightly-config.yaml
+++ b/test/resources/nightly-config.yaml
@@ -1,0 +1,99 @@
+#!productName=RHBA
+#!groovyScriptsPath=https://groovyScriptsPathUrl
+#!datetimeSuffix=
+#!communityVersion=7.33.0
+#!installerCommonsVersion=2.3.6.rhba
+#!productVersion=
+#!izpackVersion=4.5.2.rhba-redhat-00006
+#!erraiVersion=4.7.0.Final
+#!mvelVersion=2.4.3.Final-redhat-1
+#!thorntailVersion=2.5.1.Final-redhat-00010
+
+# Comprehensive list of RHBA products versions updatable with the Update Tool in the current build
+#!updatableVersionRange=7.4.1.GA-redhat-00001,7.5.1.redhat-00001
+
+#!milestone=NIGHTLY
+#!stage=GA
+#!scmRevision=main
+#!projectB-scmRevision={{scmRevision}}
+#!projectC-scmRevision={{scmRevision}}
+
+#!versionOverrideCommunity=-DversionOverride={{communityVersion}}
+#!versionOverrideUberfire=-DversionOverride={{communityVersion}}
+#!versionOverrideProduct=-DversionOverride={{productVersion}}
+#!versionOverrideIC=-DversionOverride={{installerCommonsVersion}}
+#!versionOverrideIzpack=-DversionOverride={{izpackVersion}}
+#!versionSuffix=-DversionSuffix=redhat-{{datetimeSuffix}}
+
+#!gitServer=gitServerUrl
+
+#!npm_registry=https://url/registry.npmjs.org/
+#!node_download=http://url/node/
+#!npm_download=http://url/npm/
+#!yarn_download=http://url/yarn/
+#!cypress_download=http://url/npm-libraries/cypress-3.7.0.zip
+
+
+#!baseMaven=mvn deploy -B -Dfull=true -Drevapi.skip=true -Denforcer.skip=true -Dgwt.compiler.localWorkers=1 -Dproductized=true -Dfindbugs.skip=true -Dcheckstyle.skip=true
+#!baseMavenTree={{baseMaven}}
+#!groovyScriptBase={{groovyScriptsPath}}
+
+#!starrDefine=-Dstarr.version=2.12.8.redhat-00001
+#!rhbaNameSuffix=
+#!projectNameSuffix={{productVersion}}-{{milestone}}{{rhbaNameSuffix}}
+#!communityProjectNameSuffix={{communityVersion}}-{{productVersion}}-{{milestone}}{{rhbaNameSuffix}}
+
+
+product:
+  name: {{productName}}
+  abbreviation: rhba
+  stage: {{stage}}
+  issueTrackerUrl: http://issues.jboss.org/browse/BXMSPROD
+version: {{productVersion}}
+milestone: {{milestone}}
+group: {{productName}}-{{productVersion}}-{{milestone}}-all
+defaultBuildParameters:
+  project: rhba
+  # Production env
+  environmentId: 20
+  # Stage Env
+  #  environmentId: 18
+  buildScript: {{baseMavenTree}}
+builds:
+  - name: org.kie-projectA-{{communityProjectNameSuffix}}
+    project: kiegroup/projectA
+    scmUrl: git+ssh://{{gitServer}}/kiegroup/projectA.git
+    customPmeParameters:
+      - '{{versionSuffix}}'
+
+  - name: org.kie-projectB-{{communityProjectNameSuffix}}
+    project: kiegroup/project-B
+    scmUrl: git+ssh://{{gitServer}}/kiegroup/projectB.git
+    scmRevision: {{projectB-scmRevision}}
+    buildPodMemory: 8
+    customPmeParameters:
+      - '{{versionSuffix}}'
+    dependencies:
+      - org.kie-projectA-{{communityProjectNameSuffix}}
+
+  - name: org.kie-projectC-{{communityProjectNameSuffix}}
+    project: kiegroup/projectC
+    scmUrl: git+ssh://{{gitServer}}/kiegroup/projectC.git
+    scmRevision: {{projectC-scmRevision}}
+    buildPodMemory: 8
+    alignmentParameters:
+      - '{{versionSuffix}}'
+      - '-DdepVersionOverride=x.y.z'
+    dependencies:
+      - org.kie-projectA-{{communityProjectNameSuffix}}
+
+  - name: org.kie-projectD-{{communityProjectNameSuffix}}
+    project: kiegroup/projectD
+    scmUrl: git+ssh://{{gitServer}}/kiegroup/projectD.git
+    buildPodMemory: 8
+    buildScript: mvn clean deploy
+    customPmeParameters:
+      - '{{versionSuffix}}'
+    dependencies:
+      - org.kie-projectC-{{communityProjectNameSuffix}}
+

--- a/test/vars/PmeBuildSpec.groovy
+++ b/test/vars/PmeBuildSpec.groovy
@@ -115,4 +115,31 @@ class PmeBuildSpec extends JenkinsPipelineSpecification {
         assert env['PME_BUILD_VARIABLES'].contains('projectC-scmRevision={{scmRevision}}')
         assert !env['PME_BUILD_VARIABLES'].contains('projectD-scmRevision')
     }
+
+    def "[pmebuild.groovy] parse build configuration"() {
+        setup:
+        def env = [:]
+        env['PRODUCT_VERSION'] = '1.0.0'
+        env['WORKSPACE'] = '/workspacefolder'
+        groovyScript.getBinding().setVariable("env", env)
+
+        def url = getClass().getResource('/nightly-config.yaml')
+        this.buildConfigContent = new File(url.toURI()).text
+
+        when:
+        groovyScript.parseBuildConfig('buildConfigPathFolder', [:])
+        then:
+        1 * getPipelineMock('readFile')('buildConfigPathFolder/build-config.yaml') >> { return this.buildConfigContent}
+        
+        assert env['PME_BUILD_SCRIPT_kiegroup_projectA'] == 'mvn deploy -B -Dfull=true -Drevapi.skip=true -Denforcer.skip=true -Dgwt.compiler.localWorkers=1 -Dproductized=true -Dfindbugs.skip=true -Dcheckstyle.skip=true -DaltDeploymentRepository=local::default::file:///workspacefolder/deployDirectory'
+        assert env['PME_BUILD_SCRIPT_kiegroup_project_B'] == 'mvn deploy -B -Dfull=true -Drevapi.skip=true -Denforcer.skip=true -Dgwt.compiler.localWorkers=1 -Dproductized=true -Dfindbugs.skip=true -Dcheckstyle.skip=true -DaltDeploymentRepository=local::default::file:///workspacefolder/deployDirectory'
+        assert env['PME_BUILD_SCRIPT_kiegroup_projectC'] == 'mvn deploy -B -Dfull=true -Drevapi.skip=true -Denforcer.skip=true -Dgwt.compiler.localWorkers=1 -Dproductized=true -Dfindbugs.skip=true -Dcheckstyle.skip=true -DaltDeploymentRepository=local::default::file:///workspacefolder/deployDirectory'
+        assert env['PME_BUILD_SCRIPT_kiegroup_projectD'] == 'mvn clean deploy -DaltDeploymentRepository=local::default::file:///workspacefolder/deployDirectory'
+
+        assert env['PME_ALIGNMENT_PARAMS_kiegroup_projectA'].contains('-DversionSuffix=redhat-')
+        assert env['PME_ALIGNMENT_PARAMS_kiegroup_project_B'].contains('-DversionSuffix=redhat-')
+        assert env['PME_ALIGNMENT_PARAMS_kiegroup_projectC'].contains('-DversionSuffix=redhat-')
+        assert env['PME_ALIGNMENT_PARAMS_kiegroup_projectC'].contains('-DdepVersionOverride=x.y.z')
+        assert env['PME_ALIGNMENT_PARAMS_kiegroup_projectD'].contains('-DversionSuffix=redhat-')
+    }
 }

--- a/vars/pmebuild.groovy
+++ b/vars/pmebuild.groovy
@@ -239,4 +239,39 @@ def saveBuildProjectOk(String project){
     env.ALREADY_BUILT_PROJECTS = "${env.ALREADY_BUILT_PROJECTS ?: ''}${project};"
 }
 
+/**
+ * Parse Bacon build configuration extracting PME alignment parameters and build scripts.
+ * Extracted values are exported using the following format:
+ *   - build script PME_BUILD_SCRIPT_${sanitizedProjectName}
+ *   - pme params PME_ALIGNMENT_PARAMS_${sanitizedProjectName}
+ * 
+ * @param buildConfigPathFolder the build config folder where groovy and yaml files are contained
+ * @param buildConfigAdditionalVariables additional variables
+ * @return a Map<project, Map<key, value>> where the inner map is composed by buildScript and pmeParameters
+ */
+def parseBuildConfig(String buildConfigPathFolder, Map<String, String> buildConfigAdditionalVariables) {
+    env.DATE_TIME_SUFFIX = env.DATE_TIME_SUFFIX ?: "${new Date().format(env.DATE_TIME_SUFFIX_FORMAT ?: 'yyMMdd')}"
+    env.PME_BUILD_VARIABLES = ''
+
+    println "[INFO] Parsing build configs at ${buildConfigPathFolder}. DATE_TIME_SUFFIX '${env.DATE_TIME_SUFFIX}'"
+    def buildConfigContent = readFile "${buildConfigPathFolder}/build-config.yaml"
+    Map<String, Object> buildConfigMap = getBuildConfiguration(buildConfigContent, buildConfigPathFolder, buildConfigAdditionalVariables)
+    
+    def projects = buildConfigMap['builds'].collect { it['project'] }
+    println "[INFO] Extracting build configuration for the following projects: ${projects}"
+
+    projects.each { proj ->
+        def projectConfig = getProjectConfiguration(proj, buildConfigMap)
+        def sanitizedProjectName = proj.replaceAll('/', '_').replaceAll('-', '_')
+
+        // export build script
+        def buildScript = "${projectConfig['buildScript'] ?: buildConfigMap['defaultBuildParameters']['buildScript']} -DaltDeploymentRepository=local::default::file://${env.WORKSPACE}/deployDirectory"
+        env["PME_BUILD_SCRIPT_${sanitizedProjectName}"] = buildScript
+
+        // export PME alignment parameters
+        def pmeParams = (projectConfig['alignmentParameters'] ?: projectConfig['customPmeParameters']).join(' ')
+        env["PME_ALIGNMENT_PARAMS_${sanitizedProjectName}"] = pmeParams
+    }
+}
+
 return this;


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/BXMSPROD-1981

**Change Description**:

I exposed a new function `parseBuildConfig` that aims to parse a bacon build-config.yaml exporting its parameters, the exported parameters can then be used by build-chain configuration.

The exported parameters are two:
- `PME_BUILD_SCRIPT_<project>` containing the build script for the specific project , example `PME_BUILD_SCRIPT_kiegroup_projectA=mvn clean deploy`
- `PME_ALIGNMENT_PARAMS_<project>` containing the pme alignment parameters as string "-D... -D... -D...", example `PME_ALIGNMENT_PARAMS_kiegroup_projectA=-DversionOverride=x.y.z`

> Note: the project name is generated by replacing `/` and `-` by `_`

**Referenced Pull Requests:**

- https://github.com/kiegroup/jenkins-pipeline-shared-libraries/pull/267
- https://github.com/kiegroup/drools-ansible-rulebook-integration/pull/15/
- https://github.com/kiegroup/kie-ci/pull/1450