### PR TITLE
calculateTargetReleaseBranch: handle -prod branches

### DIFF
--- a/test/vars/UtilSpec.groovy
+++ b/test/vars/UtilSpec.groovy
@@ -651,6 +651,34 @@ class UtilSpec extends JenkinsPipelineSpecification {
         version == '66.49.x'
     }
 
+    def "[util.groovy] calculateTargetReleaseBranch prod branch"() {
+        when:
+        def version = groovyScript.calculateTargetReleaseBranch('56.34.x-prod')
+        then:
+        version == '56.34.x-prod'
+    }
+
+    def "[util.groovy] calculateTargetReleaseBranch prod branch addMajor"() {
+        when:
+        def version = groovyScript.calculateTargetReleaseBranch('56.34.x-prod', 7)
+        then:
+        version == '63.34.x-prod'
+    }
+
+    def "[util.groovy] calculateTargetReleaseBranch prod branch addMajor addMinor"() {
+        when:
+        def version = groovyScript.calculateTargetReleaseBranch('56.34.x-prod', 7, 10)
+        then:
+        version == '63.44.x-prod'
+    }
+
+    def "[util.groovy] calculateTargetReleaseBranch not release branch with -prod"() {
+        when:
+        def version = groovyScript.calculateTargetReleaseBranch('56.34.x-prod-anything', 7)
+        then:
+        version == '56.34.x-prod-anything'
+    }
+
     def "[util.groovy] generateHashSize9"() {
         when:
         def hash9 = groovyScript.generateHash(9)

--- a/vars/util.groovy
+++ b/vars/util.groovy
@@ -270,10 +270,10 @@ String calculateTargetReleaseBranch(String currentReleaseBranch, int addToMajor 
     if (versionSplit.length == 3
         && versionSplit[0].isNumber()
         && versionSplit[1].isNumber()
-        && versionSplit[2] == 'x') {
+        && (versionSplit[2] == 'x' || versionSplit[2] == 'x-prod')) {
         Integer newMajor = Integer.parseInt(versionSplit[0]) + addToMajor
         Integer newMinor = Integer.parseInt(versionSplit[1]) + addToMinor
-        targetBranch = "${newMajor}.${newMinor}.x"
+        targetBranch = "${newMajor}.${newMinor}.${versionSplit[2]}"
     } else {
         println "Cannot parse targetBranch as release branch so going further with current value: ${targetBranch}"
     }


### PR DESCRIPTION
Since a while 'major.minor.x-prod' is a valid branch for which `setup-branch` should work in order to update the branch version, therefore I am extending `calculateTargetReleaseBranch` to make it working also for those branches as well. 