### PR TITLE
extended isBranchExist

### DIFF
--- a/test/vars/GithubScmSpec.groovy
+++ b/test/vars/GithubScmSpec.groovy
@@ -254,7 +254,7 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         def result = groovyScript.isBranchExist('origin', 'BRANCH')
         then:
         1 * getPipelineMock("sh")('git fetch origin')
-        1 * getPipelineMock("sh")([returnStatus: true, script: "git rev-parse BRANCH"]) >> 0
+        1 * getPipelineMock("sh")([returnStatus: true, script: "git rev-parse origin/BRANCH"]) >> 0
         result
     }
 
@@ -263,7 +263,7 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         def result = groovyScript.isBranchExist('origin', 'BRANCH')
         then:
         1 * getPipelineMock("sh")('git fetch origin')
-        1 * getPipelineMock("sh")([returnStatus: true, script: "git rev-parse BRANCH"]) >> 1
+        1 * getPipelineMock("sh")([returnStatus: true, script: "git rev-parse origin/BRANCH"]) >> 1
         !result
     }
 

--- a/vars/githubscm.groovy
+++ b/vars/githubscm.groovy
@@ -99,7 +99,7 @@ def createBranch(String branchName) {
 
 boolean isBranchExist(String remote, String branch) {
     sh "git fetch ${remote}"
-    return sh(returnStatus: true, script: "git rev-parse ${branch}") == 0
+    return sh(returnStatus: true, script: "git rev-parse ${remote}/${branch}") == 0
 }
 
 /*


### PR DESCRIPTION
@radtriste tested! 
This prevents the message: 
fatal: ambiguous argument '${branch}': unknown revision or path in the working tree 
when doing a `git rev-parse ${branch}`