### PR TITLE
NO-ISSUE: parse CHANGE_URL as fallback for PRs from origin

### DIFF
--- a/vars/pullrequest.groovy
+++ b/vars/pullrequest.groovy
@@ -62,7 +62,7 @@ void postComment(String commentText, String githubTokenCredsId = "kie-ci3-token"
         error "Pull Request Id variable (ghprbPullId or CHANGE_ID) is not set. Are you sure you are running with Github Branch Source plugin or ghprb plugin?"
     }
     def changeId = CHANGE_ID ?: ghprbPullId
-    def changeRepository = CHANGE_REPO ?: ghprbGhRepository
+    def changeRepository = CHANGE_ID ? getAuthorAndRepoForPr() : ghprbGhRepository
     String filename = "${util.generateHash(10)}.build.summary"
     def jsonComment = [
         body : commentText
@@ -73,4 +73,15 @@ void postComment(String commentText, String githubTokenCredsId = "kie-ci3-token"
         sh "curl -s -H \"Authorization: token ${GITHUB_TOKEN}\" -X POST -d '@${filename}' \"https://api.github.com/repos/${changeRepository}/issues/${changeId}/comments\""
     }
     sh "rm ${filename}"
+}
+
+String getAuthorAndRepoForPr() {
+    if (!CHANGE_FORK && !CHANGE_URL) {
+        error "CHANGE_FORK neither CHANGE_URL variables are set. Are you sure you're running with Github Branch Source plugin?"
+    }
+    if (CHANGE_FORK) {
+        return CHANGE_FORK
+    }
+    String path = new URI(CHANGE_URL).path
+    return path.substring(1, path.indexOf('/pull/'))
 }


### PR DESCRIPTION
Branch Source Plugin does only provide CHANGE_FORK variable in case of PRs coming from forks (obvious, right). When the PR is coming from repository itself (same origin), there is no env variable holding the author_name/repo_name information. Need to parse it from CHANGE_URL.
getAuthorAndRepoForPr will be handy also directly called from the Jenkinsfile.