### PR TITLE
NO-ISSUE - Output docker build logs to a file instead of standard output

### DIFF
--- a/.github/workflows/maven-tests-PR.yml
+++ b/.github/workflows/maven-tests-PR.yml
@@ -13,10 +13,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
-        java-version: 1.8
+        java-version: 8
+        distribution: temurin
+        cache: maven
     - name: Build with Maven
       run: mvn -B test --file pom.xml

--- a/test/vars/CloudSpec.groovy
+++ b/test/vars/CloudSpec.groovy
@@ -426,6 +426,15 @@ class CloudSpec extends JenkinsPipelineSpecification {
         1 * getPipelineMock("sh")("docker pull --platform PLATFORM IMAGE")
     }
 
+    def "[cloud.groovy] dockerBuildPlatformImage outputToFile"() {
+        when:
+        groovyScript.dockerBuildPlatformImage('IMAGE', 'PLATFORM', true)
+        then:
+        1 * getPipelineMock("sh")("docker buildx build --push --sbom=false --provenance=false --platform PLATFORM -t IMAGE . > IMAGE-PLATFORM-build.log")
+        1 * getPipelineMock("sh")("docker buildx imagetools inspect IMAGE")
+        1 * getPipelineMock("sh")("docker pull --platform PLATFORM IMAGE")
+    }
+
     /////////////////////////////////////////////////////////////////////
     // dockerCreateManifest
 
@@ -456,9 +465,6 @@ class CloudSpec extends JenkinsPipelineSpecification {
         then:
         1 * getPipelineMock("sh")("docker buildx rm mybuilder || true")
         1 * getPipelineMock("sh")("docker rm -f binfmt || true")
-        1 * getPipelineMock("sh")("docker context ls")
-        1 * getPipelineMock("sh")("docker buildx inspect")
-        1 * getPipelineMock("sh")("docker buildx ls")
     }
 
     def "[cloud.groovy] prepareForDockerMultiplatformBuild default"() {
@@ -474,9 +480,6 @@ class CloudSpec extends JenkinsPipelineSpecification {
         0 * getPipelineMock("sh")("cat buildkitd.toml")
         1 * getPipelineMock("sh")("docker buildx rm mybuilder || true")
         1 * getPipelineMock("sh")("docker rm -f binfmt || true")
-        1 * getPipelineMock("sh")("docker context ls")
-        1 * getPipelineMock("sh")("docker buildx inspect")
-        1 * getPipelineMock("sh")("docker buildx ls")
     }
 
     def "[cloud.groovy] prepareForDockerMultiplatformBuild with insecure registries"() {
@@ -497,9 +500,6 @@ http = true
         0 * getPipelineMock("sh")("cat buildkitd.toml")
         1 * getPipelineMock("sh")("docker buildx rm mybuilder || true")
         1 * getPipelineMock("sh")("docker rm -f binfmt || true")
-        1 * getPipelineMock("sh")("docker context ls")
-        1 * getPipelineMock("sh")("docker buildx inspect")
-        1 * getPipelineMock("sh")("docker buildx ls")
     }
 
     def "[cloud.groovy] prepareForDockerMultiplatformBuild with mirror registry"() {
@@ -549,9 +549,6 @@ http = false
         0 * getPipelineMock("sh")("cat buildkitd.toml")
         1 * getPipelineMock("sh")("docker buildx rm mybuilder || true")
         1 * getPipelineMock("sh")("docker rm -f binfmt || true")
-        1 * getPipelineMock("sh")("docker context ls")
-        1 * getPipelineMock("sh")("docker buildx inspect")
-        1 * getPipelineMock("sh")("docker buildx ls")
     }
 
     def "[cloud.groovy] prepareForDockerMultiplatformBuild with debug"() {

--- a/test/vars/CloudSpec.groovy
+++ b/test/vars/CloudSpec.groovy
@@ -432,7 +432,7 @@ class CloudSpec extends JenkinsPipelineSpecification {
         when:
         groovyScript.dockerBuildPlatformImage('IMAGE', 'PLATFORM', true)
         then:
-        1 * getPipelineMock("sh")("docker buildx build --push --sbom=false --provenance=false --platform PLATFORM -t IMAGE . > WORKSPACE/IMAGE-PLATFORM-build.log")
+        1 * getPipelineMock("sh")("docker buildx build --push --sbom=false --provenance=false --platform PLATFORM -t IMAGE . 2> WORKSPACE/IMAGE-PLATFORM-build.log")
         1 * getPipelineMock("sh")("docker buildx imagetools inspect IMAGE")
         1 * getPipelineMock("sh")("docker pull --platform PLATFORM IMAGE")
     }

--- a/test/vars/CloudSpec.groovy
+++ b/test/vars/CloudSpec.groovy
@@ -427,10 +427,12 @@ class CloudSpec extends JenkinsPipelineSpecification {
     }
 
     def "[cloud.groovy] dockerBuildPlatformImage outputToFile"() {
+        setup:
+        groovyScript.getBinding().setVariable("WORKSPACE", "WORKSPACE")
         when:
         groovyScript.dockerBuildPlatformImage('IMAGE', 'PLATFORM', true)
         then:
-        1 * getPipelineMock("sh")("docker buildx build --push --sbom=false --provenance=false --platform PLATFORM -t IMAGE . > IMAGE-PLATFORM-build.log")
+        1 * getPipelineMock("sh")("docker buildx build --push --sbom=false --provenance=false --platform PLATFORM -t IMAGE . > WORKSPACE/IMAGE-PLATFORM-build.log")
         1 * getPipelineMock("sh")("docker buildx imagetools inspect IMAGE")
         1 * getPipelineMock("sh")("docker pull --platform PLATFORM IMAGE")
     }

--- a/vars/cloud.groovy
+++ b/vars/cloud.groovy
@@ -183,7 +183,10 @@ void dockerBuildMultiPlatformImages(String buildImageTag, List platforms, boolea
 * You should have run `prepareForDockerMultiplatformBuild` method before executing this method
 */
 void dockerBuildPlatformImage(String buildImageTag, String platform, boolean outputToFile = false) {
-    sh "docker buildx build --push --sbom=false --provenance=false --platform ${platform} -t ${buildImageTag} .${outputToFile ? ' > ' + buildImageTag + '-' + platform + '-build.log' : ''}"
+    def logFileName = (buildImageTag + '-' + platform + '-build.log')
+        .replaceAll('/','_')
+        .replaceAll(':','_')
+    sh "docker buildx build --push --sbom=false --provenance=false --platform ${platform} -t ${buildImageTag} .${outputToFile ? ' 2> ' + "${WORKSPACE}/${logFileName}" : ''}"
     sh "docker buildx imagetools inspect ${buildImageTag}"
     sh "docker pull --platform ${platform} ${buildImageTag}"
 }

--- a/vars/cloud.groovy
+++ b/vars/cloud.groovy
@@ -154,7 +154,7 @@ void dockerDebugImage(String imageTag) {
 *
 * You should have run `prepareForDockerMultiplatformBuild` method before executing this method
 */
-void dockerBuildMultiPlatformImages(String buildImageTag, List platforms, boolean squashImages = true, String squashMessage = "Squashed ${buildImageTag}", boolean debug = false) {
+void dockerBuildMultiPlatformImages(String buildImageTag, List platforms, boolean squashImages = true, String squashMessage = "Squashed ${buildImageTag}", boolean debug = false, boolean outputToFile = false) {
     // Build image locally in tgz file
     List buildPlatformImages = platforms.collect { platform ->
         String os_arch = platform.replaceAll('/', '-')
@@ -162,7 +162,7 @@ void dockerBuildMultiPlatformImages(String buildImageTag, List platforms, boolea
         String finalPlatformImage = platformImage
 
         // Build
-        dockerBuildPlatformImage(platformImage, platform)
+        dockerBuildPlatformImage(platformImage, platform, outputToFile)
         if (debug) { dockerDebugImage(platformImage) }
 
         if (squashImages) {
@@ -182,8 +182,8 @@ void dockerBuildMultiPlatformImages(String buildImageTag, List platforms, boolea
 *
 * You should have run `prepareForDockerMultiplatformBuild` method before executing this method
 */
-void dockerBuildPlatformImage(String buildImageTag, String platform) {
-    sh "docker buildx build --push --sbom=false --provenance=false --platform ${platform} -t ${buildImageTag} ."
+void dockerBuildPlatformImage(String buildImageTag, String platform, boolean outputToFile = false) {
+    sh "docker buildx build --push --sbom=false --provenance=false --platform ${platform} -t ${buildImageTag} . ${outputToFile ? '> ' + buildImageTag + '-' + platform + '-build.log' : ''}"
     sh "docker buildx imagetools inspect ${buildImageTag}"
     sh "docker pull --platform ${platform} ${buildImageTag}"
 }
@@ -207,7 +207,7 @@ void dockerCreateManifest(String buildImageTag, List manifestImages) {
 *         - insecure: whether the mirror is insecure
 */
 void prepareForDockerMultiplatformBuild(List insecureRegistries = [], List mirrorRegistriesConfig = [], boolean debug = false) {
-    cleanDockerMultiplatformBuild()
+    cleanDockerMultiplatformBuild(debug)
 
     // For multiplatform build
     sh 'docker run --rm --privileged --name binfmt docker.io/tonistiigi/binfmt --install all'
@@ -275,10 +275,10 @@ void debugDockerMultiplatformBuild() {
 /*
 * Clean the node from Docker multiplatform configuration
 */
-void cleanDockerMultiplatformBuild() {
+void cleanDockerMultiplatformBuild(boolean debug = false) {
     sh 'docker buildx rm mybuilder || true'
     sh 'docker rm -f binfmt || true'
-    debugDockerMultiplatformBuild()
+    if (debug) { debugDockerMultiplatformBuild() }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////

--- a/vars/cloud.groovy
+++ b/vars/cloud.groovy
@@ -183,7 +183,7 @@ void dockerBuildMultiPlatformImages(String buildImageTag, List platforms, boolea
 * You should have run `prepareForDockerMultiplatformBuild` method before executing this method
 */
 void dockerBuildPlatformImage(String buildImageTag, String platform, boolean outputToFile = false) {
-    sh "docker buildx build --push --sbom=false --provenance=false --platform ${platform} -t ${buildImageTag} . ${outputToFile ? '> ' + buildImageTag + '-' + platform + '-build.log' : ''}"
+    sh "docker buildx build --push --sbom=false --provenance=false --platform ${platform} -t ${buildImageTag} .${outputToFile ? ' > ' + buildImageTag + '-' + platform + '-build.log' : ''}"
     sh "docker buildx imagetools inspect ${buildImageTag}"
     sh "docker pull --platform ${platform} ${buildImageTag}"
 }


### PR DESCRIPTION
Docker build can be really verbose duo to Cekit nature and the whole modules we use in our images. This pollutes the pipelines logs, making debug and troubleshooting quite a challenge. Instead, I've added an option to send this output to a log file, so the pipeline node can archive the result in the `post` stage. The file name has the image plus the platform suffix. Pretty easy to write a regex to archive it after the build.

This PR won't change the default behavior, but pipelines have the option to turnoff the image build logs now.

~Do you guys know how do I test this?~ I've figured.