### PR TITLE
Sonar.login is deprecated use instead Sonar.token

### DIFF
--- a/test/vars/MavenSpec.groovy
+++ b/test/vars/MavenSpec.groovy
@@ -113,7 +113,7 @@ class MavenSpec extends JenkinsPipelineSpecification {
         mavenGroovy.runMavenWithSettingsSonar("settings.xml", "clean install", "sonarCloudId", "logFile.txt")
         then:
         1 * getPipelineMock("sh")([returnStdout: true, script: 'mktemp --suffix -settings.xml']) >> 'anything-settings.xml'
-        1 * getPipelineMock("sh")([script: 'mvn -B -s settingsFileId clean install -Dsonar.login=tokenId | tee $WORKSPACE/logFile.txt ; test ${PIPESTATUS[0]} -eq 0', returnStdout: false])
+        1 * getPipelineMock("sh")([script: 'mvn -B -s settingsFileId clean install -Dsonar.token=tokenId | tee $WORKSPACE/logFile.txt ; test ${PIPESTATUS[0]} -eq 0', returnStdout: false])
     }
 
     def "[maven.groovy] run Maven sonar settings without log file"() {
@@ -124,7 +124,7 @@ class MavenSpec extends JenkinsPipelineSpecification {
         mavenGroovy.runMavenWithSettingsSonar("settings.xml", "clean install", "sonarCloudId")
         then:
         1 * getPipelineMock("sh")([returnStdout: true, script: 'mktemp --suffix -settings.xml']) >> 'anything-settings.xml'
-        1 * getPipelineMock("sh")([script: 'mvn -B -s settingsFileId clean install -Dsonar.login=tokenId', returnStdout: false])
+        1 * getPipelineMock("sh")([script: 'mvn -B -s settingsFileId clean install -Dsonar.token=tokenId', returnStdout: false])
     }
 
     def "[maven.groovy] run with Settings with log file"() {

--- a/vars/maven.groovy
+++ b/vars/maven.groovy
@@ -55,7 +55,7 @@ def runMavenWithSettingsSonar(String settingsXmlId, String goals, String sonarCl
     withCredentials([string(credentialsId: sonarCloudId, variable: 'TOKEN')]) {
         new MavenCommand(this)
                 .withSettingsXmlId(settingsXmlId)
-                .withProperty('sonar.login', "${TOKEN}")
+                .withProperty('sonar.token', "${TOKEN}")
                 .withLogFileName(logFileName)
                 .run(goals)
     }


### PR DESCRIPTION
Fixing a warning `[WARNING] The property 'sonar.login' is deprecated and will be removed in the future. Please use the 'sonar.token' property instead when passing a token.`
